### PR TITLE
Fix `sys_writev` return value in `arceos_posix_api`

### DIFF
--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -1,5 +1,5 @@
 use crate::ctypes;
-use axerrno::LinuxError;
+use axerrno::{LinuxError, LinuxResult};
 use core::ffi::{c_int, c_void};
 
 #[cfg(feature = "fd")]
@@ -30,27 +30,29 @@ pub fn sys_read(fd: c_int, buf: *mut c_void, count: usize) -> ctypes::ssize_t {
     })
 }
 
+fn write_impl(fd: c_int, buf: *const c_void, count: usize) -> LinuxResult<ctypes::ssize_t> {
+    if buf.is_null() {
+        return Err(LinuxError::EFAULT);
+    }
+    let src = unsafe { core::slice::from_raw_parts(buf as *const u8, count) };
+    #[cfg(feature = "fd")]
+    {
+        Ok(get_file_like(fd)?.write(src)? as ctypes::ssize_t)
+    }
+    #[cfg(not(feature = "fd"))]
+    match fd {
+        0 => Err(LinuxError::EPERM),
+        1 | 2 => Ok(super::stdio::stdout().write(src)? as ctypes::ssize_t),
+        _ => Err(LinuxError::EBADF),
+    }
+}
+
 /// Write data to the file indicated by `fd`.
 ///
 /// Return the written size if success.
 pub fn sys_write(fd: c_int, buf: *const c_void, count: usize) -> ctypes::ssize_t {
     debug!("sys_write <= {} {:#x} {}", fd, buf as usize, count);
-    syscall_body!(sys_write, {
-        if buf.is_null() {
-            return Err(LinuxError::EFAULT);
-        }
-        let src = unsafe { core::slice::from_raw_parts(buf as *const u8, count) };
-        #[cfg(feature = "fd")]
-        {
-            Ok(get_file_like(fd)?.write(src)? as ctypes::ssize_t)
-        }
-        #[cfg(not(feature = "fd"))]
-        match fd {
-            0 => Err(LinuxError::EPERM),
-            1 | 2 => Ok(super::stdio::stdout().write(src)? as ctypes::ssize_t),
-            _ => Err(LinuxError::EBADF),
-        }
-    })
+    syscall_body!(sys_write, write_impl(fd, buf, count))
 }
 
 /// Write a vector.
@@ -64,7 +66,7 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            ret += sys_write(fd, iov.iov_base, iov.iov_len);
+            ret += write_impl(fd, iov.iov_base, iov.iov_len)?;
         }
 
         Ok(ret)


### PR DESCRIPTION
The current `sys_writev` implementation does not return a correct error value if one of the write calls fails. Instead it adds the number of bytes written and any error codes, leading to a meaningless result. This PR fixes it by returning the error early.