### PR TITLE
Reimplement AddrSpace clone

### DIFF
--- a/modules/axmm/src/backend/alloc.rs
+++ b/modules/axmm/src/backend/alloc.rs
@@ -26,7 +26,6 @@ impl Backend {
     }
 
     pub(crate) fn map_alloc(
-        &self,
         start: VirtAddr,
         size: usize,
         flags: MappingFlags,
@@ -62,7 +61,6 @@ impl Backend {
     }
 
     pub(crate) fn unmap_alloc(
-        &self,
         start: VirtAddr,
         size: usize,
         pt: &mut PageTable,
@@ -86,7 +84,6 @@ impl Backend {
     }
 
     pub(crate) fn handle_page_fault_alloc(
-        &self,
         vaddr: VirtAddr,
         orig_flags: MappingFlags,
         pt: &mut PageTable,

--- a/modules/axmm/src/backend/linear.rs
+++ b/modules/axmm/src/backend/linear.rs
@@ -10,7 +10,6 @@ impl Backend {
     }
 
     pub(crate) fn map_linear(
-        &self,
         start: VirtAddr,
         size: usize,
         flags: MappingFlags,
@@ -32,7 +31,6 @@ impl Backend {
     }
 
     pub(crate) fn unmap_linear(
-        &self,
         start: VirtAddr,
         size: usize,
         pt: &mut PageTable,

--- a/modules/axmm/src/backend/mod.rs
+++ b/modules/axmm/src/backend/mod.rs
@@ -44,15 +44,15 @@ impl MappingBackend for Backend {
     type PageTable = PageTable;
     fn map(&self, start: VirtAddr, size: usize, flags: MappingFlags, pt: &mut PageTable) -> bool {
         match *self {
-            Self::Linear { pa_va_offset } => self.map_linear(start, size, flags, pt, pa_va_offset),
-            Self::Alloc { populate } => self.map_alloc(start, size, flags, pt, populate),
+            Self::Linear { pa_va_offset } => Self::map_linear(start, size, flags, pt, pa_va_offset),
+            Self::Alloc { populate } => Self::map_alloc(start, size, flags, pt, populate),
         }
     }
 
     fn unmap(&self, start: VirtAddr, size: usize, pt: &mut PageTable) -> bool {
         match *self {
-            Self::Linear { pa_va_offset } => self.unmap_linear(start, size, pt, pa_va_offset),
-            Self::Alloc { populate } => self.unmap_alloc(start, size, pt, populate),
+            Self::Linear { pa_va_offset } => Self::unmap_linear(start, size, pt, pa_va_offset),
+            Self::Alloc { populate } => Self::unmap_alloc(start, size, pt, populate),
         }
     }
 
@@ -80,7 +80,7 @@ impl Backend {
         match *self {
             Self::Linear { .. } => false, // Linear mappings should not trigger page faults.
             Self::Alloc { populate } => {
-                self.handle_page_fault_alloc(vaddr, orig_flags, page_table, populate)
+                Self::handle_page_fault_alloc(vaddr, orig_flags, page_table, populate)
             }
         }
     }


### PR DESCRIPTION
Current `AddrSpace::clone_or_err` cannot handle allocation mappings with `populate=false`. There are two cases where it may fail:
1. The source area is never allocated or partially allocated (by handling page faults), causing `self.read` to fail. In this case, we should ignore virtual pages that are not physically allocated.
2. `process_area_data_with_page_table` **always** fails because the destination area has no pages allocated. In this case, we should allocate physical pages before writing.

The implementation of this PR fixes the issue by skipping unmapped pages in the source area and trying to allocate pages for unmapped pages in the destination area. This implementation also removes `buf` and copies data directly from area to area, which should improve performance.