### PR TITLE
Patch axmm_crates to use our fix & add `AddrSpace::check_region_access`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,15 +1254,15 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memory_addr"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f769efcf10b9dfb4c913bebb409cda77b1a3f072b249bf5465e250bcb30eb49"
+checksum = "5438b8df0f13e16e1f46140de247695a95952a5a4479e47197a8711bf1063373"
 
 [[package]]
 name = "memory_set"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335675b7ab07460f532d3b2b557313be73037fdf81b65464d8c0d8bd90d2fbf9"
+checksum = "a4552d02c866c57e8b06b919ea8c2f8f398cad245b8f6aac726657bc972d663d"
 dependencies = [
  "memory_addr",
 ]

--- a/modules/axmm/Cargo.toml
+++ b/modules/axmm/Cargo.toml
@@ -20,7 +20,3 @@ lazyinit = "0.2"
 memory_addr = "0.3"
 kspin = "0.1"
 memory_set = "0.3"
-
-[patch.crates-io]
-memory_addr = { git = "https://github.com/Mivik/axmm_crates.git", rev = "45ac2ac" }
-memory_set = { git = "https://github.com/Mivik/axmm_crates.git", rev = "45ac2ac" }

--- a/modules/axmm/Cargo.toml
+++ b/modules/axmm/Cargo.toml
@@ -20,3 +20,7 @@ lazyinit = "0.2"
 memory_addr = "0.3"
 kspin = "0.1"
 memory_set = "0.3"
+
+[patch.crates-io]
+memory_addr = { git = "https://github.com/Mivik/axmm_crates.git", rev = "45ac2ac" }
+memory_set = { git = "https://github.com/Mivik/axmm_crates.git", rev = "45ac2ac" }

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -320,6 +320,37 @@ impl AddrSpace {
         self.areas.clear(&mut self.pt).unwrap();
     }
 
+    /// Checks whether an access to the specified memory region is valid.
+    ///
+    /// Returns `true` if the memory region given by `range` is all mapped and
+    /// has proper permission flags (i.e. containing `access_flags`).
+    pub fn check_region_access(
+        &self,
+        mut range: VirtAddrRange,
+        access_flags: MappingFlags,
+    ) -> bool {
+        for area in self.areas.iter() {
+            if area.end() <= range.start {
+                continue;
+            }
+            if area.start() > range.start {
+                return false;
+            }
+
+            // This area overlaps with the memory region
+            if area.flags().contains(access_flags) {
+                return false;
+            }
+
+            range.start = area.end();
+            if range.is_empty() {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Handles a page fault at the given address.
     ///
     /// `access_flags` indicates the access type that caused the page fault.

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -330,15 +330,12 @@ impl AddrSpace {
         access_flags: MappingFlags,
     ) -> bool {
         for area in self.areas.iter() {
-            if area.end() <= range.start {
-                continue;
-            }
             if area.start() > range.start {
                 return false;
             }
 
             // This area overlaps with the memory region
-            if area.flags().contains(access_flags) {
+            if !area.flags().contains(access_flags) {
                 return false;
             }
 


### PR DESCRIPTION
See https://github.com/arceos-org/axmm_crates/pull/6

The upstream `axmm_crates` contains an implementation bug that causes `MemorySet::find_free_area` to degenerate. This PR patches `axmm_crates` to apply the fix.