### PR TITLE
Fix fd table behaviours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 [[package]]
 name = "flatten_objects"
 version = "0.2.2"
-source = "git+https://github.com/AsakuraMizu/flatten_objects.git?rev=5b6820b#5b6820bb80d718461e8d51b8188165b054ff0e29"
+source = "git+https://github.com/arceos-org/flatten_objects.git?rev=8da6573#8da65738b333b87abf1a2db35a6a9df532a4d3ae"
 dependencies = [
  "bitmaps",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,9 +969,8 @@ dependencies = [
 
 [[package]]
 name = "flatten_objects"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593e2a150ea7985fb62614fac12bb1dec8d91ea3a92bc2cbd07746b289645a3"
+version = "0.2.2"
+source = "git+https://github.com/AsakuraMizu/flatten_objects.git?rev=5b6820b#5b6820bb80d718461e8d51b8188165b054ff0e29"
 dependencies = [
  "bitmaps",
 ]

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -48,7 +48,7 @@ axns = { workspace = true, optional = true }
 # Other crates
 axio = "0.1"
 axerrno = "0.1"
-flatten_objects = { git = "https://github.com/AsakuraMizu/flatten_objects.git", rev = "5b6820b" }
+flatten_objects = { git = "https://github.com/arceos-org/flatten_objects.git", rev = "8da6573" }
 static_assertions = "1.1.0"
 spin = { version = "0.9" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -48,11 +48,11 @@ axns = { workspace = true, optional = true }
 # Other crates
 axio = "0.1"
 axerrno = "0.1"
-flatten_objects = "0.2"
+flatten_objects = { git = "https://github.com/AsakuraMizu/flatten_objects.git", rev = "5b6820b" }
 static_assertions = "1.1.0"
 spin = { version = "0.9" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }
 ctor_bare = "0.2"
 
 [build-dependencies]
-bindgen ={ version = "0.69" }
+bindgen = { version = "0.69" }

--- a/api/arceos_posix_api/src/imp/fd_ops.rs
+++ b/api/arceos_posix_api/src/imp/fd_ops.rs
@@ -31,9 +31,8 @@ impl FD_TABLE {
     pub fn copy_inner(&self) -> RwLock<FlattenObjects<Arc<dyn FileLike>, AX_FILE_LIMIT>> {
         let table = self.read();
         let mut new_table = FlattenObjects::new();
-        let count = table.count();
-        for i in 0..count {
-            let _ = new_table.add_at(i, table.get(i).unwrap().clone());
+        for id in table.ids() {
+            let _ = new_table.add_at(id, table.get(id).unwrap().clone());
         }
         RwLock::new(new_table)
     }


### PR DESCRIPTION
~*Temporarily using my own fork of `flatten_objects`, blocked by upstream: arceos-org/flatten_objects#2*~  
*The upstream has merged the PR but not yet released*

Some functions using `fd_table.count()` have incorrect behaviours: they assume `count` to be maximum file descriptor.

To fix it, I have added an `ids` method on upstream `FlattenObjects` to retrive all open file descriptors to make `copy_inner` work properly. The other two use cases are redundant since `Directory::from_fd` already checks the validity of the file descriptor.