### PR TITLE
Fix incorrect writev implementation

### DIFF
--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -64,7 +64,15 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            ret += sys_write(fd, iov.iov_base, iov.iov_len);
+            let result = sys_write(fd, iov.iov_base, iov.iov_len);
+            if result < 0 {
+                return Ok(result);
+            }
+            ret += result;
+
+            if result < iov.iov_len as isize {
+                break;
+            }
         }
 
         Ok(ret)


### PR DESCRIPTION
## Description  

Current implementation of `writev` does not respect errors from `write`. Meanwhile, its implementation is incorrect. According to the Linux manual:

> Buffers are processed in array order. This means that readv() completely fills iov[0] before proceeding to iov[1], and so on. (If there is insufficient data, then not all buffers pointed to by iov may be filled.) Similarly, writev() writes out the entire contents of iov[0] before proceeding to iov[1], and so on.

The old implementation will always process each buffer regardless of the result of the previous buffers.

## Implementation Details  

This implementations checks the result of `sys_writev` with care, aborting the process early if one buffer fails to be fully written out.
