### PR TITLE
chore: update flatten_objects to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,8 +969,9 @@ dependencies = [
 
 [[package]]
 name = "flatten_objects"
-version = "0.2.2"
-source = "git+https://github.com/arceos-org/flatten_objects.git?rev=8da6573#8da65738b333b87abf1a2db35a6a9df532a4d3ae"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e362dae0b64fc12551b655a09484a643461a283a078fb8a9686d1f58fa46df9a"
 dependencies = [
  "bitmaps",
 ]

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -48,7 +48,7 @@ axns = { workspace = true, optional = true }
 # Other crates
 axio = "0.1"
 axerrno = "0.1"
-flatten_objects = { git = "https://github.com/arceos-org/flatten_objects.git", rev = "8da6573" }
+flatten_objects = "0.2"
 static_assertions = "1.1.0"
 spin = { version = "0.9" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }


### PR DESCRIPTION
## Description  
Upstream [flatten_objects](https://github.com/arceos-org/flatten_objects) has released its fix.

## Related
#6 
