### PR TITLE
Update `flatten_objects` version & Fix `check_region_access`

### DIFF
--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -48,7 +48,7 @@ axns = { workspace = true, optional = true }
 # Other crates
 axio = "0.1"
 axerrno = "0.1"
-flatten_objects = "0.2"
+flatten_objects = "0.2.3"
 static_assertions = "1.1.0"
 spin = { version = "0.9" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -329,6 +329,9 @@ impl AddrSpace {
         access_flags: MappingFlags,
     ) -> bool {
         for area in self.areas.iter() {
+            if area.end() <= range.start {
+                continue;
+            }
             if area.start() > range.start {
                 return false;
             }


### PR DESCRIPTION
## Description  

`flatten_objects` version is updated to `0.2.3` to avoid unexpected build failure. This PR also includes a small fix to `check_region_access` where areas before the region to be checked could affect the result of the function.

## Implementation Details  

See commits.
