### PR TITLE
fix: don't map to zero address for lazily allocated memory area

### DIFF
--- a/modules/axmm/src/backend/alloc.rs
+++ b/modules/axmm/src/backend/alloc.rs
@@ -50,6 +50,8 @@ impl Backend {
                     }
                 }
             }
+        } else {
+            // create mapping entries on demand later in `handle_page_fault_alloc`.
         }
         true
     }

--- a/modules/axmm/src/backend/alloc.rs
+++ b/modules/axmm/src/backend/alloc.rs
@@ -50,14 +50,8 @@ impl Backend {
                     }
                 }
             }
-            true
-        } else {
-            // Map to a empty entry for on-demand mapping.
-            let flags = MappingFlags::empty();
-            pt.map_region(start, |_| 0.into(), size, flags, false, false)
-                .map(|tlb| tlb.ignore())
-                .is_ok()
         }
+        true
     }
 
     pub(crate) fn unmap_alloc(
@@ -94,9 +88,9 @@ impl Backend {
         } else if let Some(frame) = alloc_frame(true) {
             // Allocate a physical frame lazily and map it to the fault address.
             // `vaddr` does not need to be aligned. It will be automatically
-            // aligned during `pt.remap` regardless of the page size.
-            pt.remap(vaddr, frame, orig_flags)
-                .map(|(_, tlb)| tlb.flush())
+            // aligned during `pt.map` regardless of the page size.
+            pt.map(vaddr, frame, PageSize::Size4K, orig_flags)
+                .map(|tlb| tlb.flush())
                 .is_ok()
         } else {
             false


### PR DESCRIPTION
## Description
This is an alternative for #10. This PR tries to avoid `pt.query` from returning zero address from source.

## Implementation Details
Previously we map lazily allocated memory area to a physical address `0`, and later `remap` to actual address on page fault. In this PR, we no longer create such invalid PTEs, but don't create any PTE at all.

See https://github.com/oscomp/arceos/pull/10#issuecomment-2711340462.

## How to Test
This PR mainly infects `clone` and `fork` so I'm showing these two testcases.
|x86_64|aarch64|riscv64|loongarch64|
|-|-|-|-|
|![图片](https://github.com/user-attachments/assets/727f8cda-e79a-4e57-8c4f-7d4502aed6fe)|![图片](https://github.com/user-attachments/assets/af1e9052-11b8-41c4-a2c2-5db38662e000)|![图片](https://github.com/user-attachments/assets/93827869-1936-4745-b282-8224864d667d)|![图片](https://github.com/user-attachments/assets/d38a2fc5-7ee2-46db-9cc6-22fed55fca9c)|