### PR TITLE
Upgrade axio to 0.1.1 and utilize default_read_to_end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "axio"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ca9c10ea4cd42bda87a2abde281fb481c76a0b05976fd03697385ea65d5122"
+checksum = "30aa258a37c25c5e9d3ff45ec80e728ff7c499586e3e40719daf7908f10fd5bd"
 dependencies = [
  "axerrno",
 ]

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -26,7 +26,7 @@ log = "=0.4.21"
 cfg-if = "1.0"
 lazyinit = "0.2"
 cap_access = "0.1"
-axio = { version = "0.1", features = ["alloc"] }
+axio = { version = "0.1.1", features = ["alloc"] }
 axerrno = "0.1"
 axfs_vfs = "0.1"
 spin = "0.9"

--- a/modules/axfs/src/api/file.rs
+++ b/modules/axfs/src/api/file.rs
@@ -1,4 +1,5 @@
-use axio::{Result, SeekFrom, prelude::*};
+use alloc::vec::Vec;
+use axio::{Result, SeekFrom, default_read_to_end, prelude::*};
 use core::fmt;
 
 use crate::fops;
@@ -173,6 +174,14 @@ impl File {
 impl Read for File {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.inner.read(buf)
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
+        default_read_to_end(
+            self,
+            buf,
+            self.metadata().ok().map(|metadata| metadata.size() as _),
+        )
     }
 }
 


### PR DESCRIPTION
## Description
This PR upgrade `axio` to 0.1.1, which greatly improved `read_to_end` performance.

## Implementation Details
See https://github.com/arceos-org/axio/pull/1

## Performance Gains
- Previous time for running through all basic testcases except `sleep` (31 programs, each ~55KiB) on riscv64: 40.570544112s
- After this upgrade: 931.4604ms
- Previous time for running `/musl/busybox echo "Hello, World!"` (1.1MiB): 1.2493267s
- After this upgrade: 38.0424ms