### PR TITLE
Fix kernel stack position on LoongArch64

### DIFF
--- a/modules/axhal/src/arch/loongarch64/trap.S
+++ b/modules/axhal/src/arch/loongarch64/trap.S
@@ -27,6 +27,8 @@
     csrwr   $r21, KSAVE_R21
     LDD     $tp,  $sp, 2
     LDD     $r21, $sp, 21
+    addi.d  $t1,  $sp, {trapframe_size}
+    csrwr   $t1,  KSAVE_KSP // save kernel sp
 .endif
 
     LDD     $t1,  $sp, 33       // era


### PR DESCRIPTION
## Description
This PR fixes support on LoongArch64 after we sync with upstream.

## Implementation Details
I compared latest code with previous https://github.com/oscomp/arceos/blob/old_main_0314/modules/axhal/src/arch/loongarch64/trap.S and found these lines missing. I also referred to https://github.com/oscomp/arceos/blob/main/modules/axhal/src/arch/riscv/trap.S and learned that this operation of saving kernel sp only needs to be performed when the exception handler exits after handling the user mode exception.

## How to Test
This issue currently only affects `yield` in basic testcases on LoongArch64, which involves repeated context switches.

Before this PR:
![图片](https://github.com/user-attachments/assets/85c3ad44-c075-4d12-a317-5e206fc87149)

After this PR:
![图片](https://github.com/user-attachments/assets/e53572c2-3f30-4922-b2d8-db6e4d0281ee)

## Additional Notes
I have no idea why upstream accidentally dropped it. Maybe we should port it upstream later as well.