### PR TITLE
fix: open directory

### DIFF
--- a/modules/axfs/src/api/file.rs
+++ b/modules/axfs/src/api/file.rs
@@ -17,7 +17,7 @@ pub struct File {
 }
 
 /// Metadata information about a file.
-pub struct Metadata(fops::FileAttr);
+pub struct Metadata(pub(super) fops::FileAttr);
 
 /// Options and flags which can be used to configure how a file is opened.
 #[derive(Default, Clone, Debug)]

--- a/modules/axfs/src/api/file.rs
+++ b/modules/axfs/src/api/file.rs
@@ -20,14 +20,8 @@ pub struct File {
 pub struct Metadata(fops::FileAttr);
 
 /// Options and flags which can be used to configure how a file is opened.
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct OpenOptions(fops::OpenOptions);
-
-impl Default for OpenOptions {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl OpenOptions {
     /// Creates a blank new set of options ready for configuration.

--- a/modules/axfs/src/api/mod.rs
+++ b/modules/axfs/src/api/mod.rs
@@ -56,7 +56,7 @@ pub fn write<C: AsRef<[u8]>>(path: &str, contents: C) -> io::Result<()> {
 /// Given a path, query the file system to get information about a file,
 /// directory, etc.
 pub fn metadata(path: &str) -> io::Result<Metadata> {
-    File::open(path)?.metadata()
+    crate::root::lookup(None, path)?.get_attr().map(Metadata)
 }
 
 /// Creates a new, empty directory at the provided path.

--- a/modules/axfs/src/fops.rs
+++ b/modules/axfs/src/fops.rs
@@ -308,6 +308,9 @@ impl Directory {
 
         node.open()?;
         Ok(Self {
+            // Here we use `cap` as capability instead of `access_cap` to allow the user to manipulate the directory
+            // without explicitly setting [`OpenOptions::execute`], but without requiring execute access even for
+            // directories that don't have this permission.
             node: WithCap::new(node, cap),
             entry_idx: 0,
         })

--- a/modules/axfs/src/fops.rs
+++ b/modules/axfs/src/fops.rs
@@ -35,7 +35,7 @@ pub struct Directory {
 }
 
 /// Options and flags which can be used to configure how a file is opened.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct OpenOptions {
     // generic
     read: bool,
@@ -177,9 +177,7 @@ impl File {
         };
 
         let attr = node.get_attr()?;
-        if attr.is_dir()
-            && (opts.create || opts.create_new || opts.write || opts.append || opts.truncate)
-        {
+        if attr.is_dir() {
             return ax_err!(IsADirectory);
         }
         let access_cap = opts.into();
@@ -303,13 +301,14 @@ impl Directory {
             return ax_err!(NotADirectory);
         }
         let access_cap = opts.into();
-        if !perm_to_cap(attr.perm()).contains(access_cap) {
+        let cap = perm_to_cap(attr.perm());
+        if !cap.contains(access_cap) {
             return ax_err!(PermissionDenied);
         }
 
         node.open()?;
         Ok(Self {
-            node: WithCap::new(node, access_cap),
+            node: WithCap::new(node, cap),
             entry_idx: 0,
         })
     }

--- a/modules/axfs/tests/test_common/mod.rs
+++ b/modules/axfs/tests/test_common/mod.rs
@@ -201,8 +201,7 @@ fn test_devfs_ramfs() -> Result<()> {
 
     // stat /dev
     let dname = "/dev";
-    let dir = File::open(dname)?;
-    let md = dir.metadata()?;
+    let md = fs::metadata(dname)?;
     println!("metadata of {:?}: {:?}", dname, md);
     assert_eq!(md.file_type(), FileType::Dir);
     assert!(!md.is_file());
@@ -210,8 +209,7 @@ fn test_devfs_ramfs() -> Result<()> {
 
     // stat /dev/foo/bar
     let fname = ".//.///././/./dev///.///./foo//././bar";
-    let file = File::open(fname)?;
-    let md = file.metadata()?;
+    let md = fs::metadata(fname)?;
     println!("metadata of {:?}: {:?}", fname, md);
     assert_eq!(md.file_type(), FileType::CharDevice);
     assert!(!md.is_dir());


### PR DESCRIPTION
## Description
This PR fixes several issues with opening directories:
1. Directories may be opened as files (`File::_open_at`).
2. Directories must be opened with execute permission, otherwise methods that require the directory to be executable (such as `open_dir_at`, `create_file` and `remove_file`) cannot be used.
3. `sys_openat` ignores `O_DIRECTORY`.

Also fixes a clippy warning and removes some unused fields in `OpenOptions`.

## Implementation Details
For the first issue, we just make `File::_open_at` return an error as long as `node` is a directory.

For the second, one might say it's correct to require execute permissions on the directory. But this does not mean that `O_EXEC` needs to be explicitly specified when opening the directory to access the directory contents. One might also ask why not automatically specify `execute` on `OpenOptions` when opening a directory. This approach will result in the inability to open directories without execute permissions. As a result, I ended up using implicit inheritance of the folder's own permissions, with `OpenOptions` only used for permission checking.

For the third, I move the part that checks `options.has_directory()` into `add_file_or_directory_fd` to make this function more generic.

## How to Test
This is heavily related to testcase `getdents` and `openat`.

Before this PR (note that although `getdents success.` is printed, it displays no content below):
![图片](https://github.com/user-attachments/assets/ce420818-45b9-46ba-b79e-9dd02670f9c5)

After this PR:
![图片](https://github.com/user-attachments/assets/f5728720-c471-409f-aa3e-b408ea17a544)

## Additional Notes
Previously disscussed at https://github.com/oscomp/starry-next/issues/3#issuecomment-2708922562.

Other students' solutions to this problem:
- https://ressed.github.io/GraduationProjectRecords/#/docs/spring/Week2%20(3.3)?id=getdents
- https://github.com/wang-jiahua/arceos/commit/677facb48694598b1740094e465e8d81a2a3a789