### PR TITLE
Add support for signal handling

### DIFF
--- a/api/arceos_posix_api/build.rs
+++ b/api/arceos_posix_api/build.rs
@@ -53,6 +53,7 @@ typedef struct {{
             "clockid_t",
             "rlimit",
             "aibuf",
+            "siginfo_t",
         ];
         let allow_vars = [
             "CLOCK_.*",

--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -96,6 +96,8 @@ SECTIONS {
     linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
     linkme_SYSCALL : { *(linkme_SYSCALL) }
     linkm2_SYSCALL : { *(linkm2_SYSCALL) }
+    linkme_ANY_TRAP : { *(linkme_ANY_TRAP) }
+    linkm2_ANY_TRAP : { *(linkm2_ANY_TRAP) }
     axns_resource : { *(axns_resource) }
 }
 INSERT AFTER .tbss;

--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -11,6 +11,8 @@ SECTIONS
     .text : ALIGN(4K) {
         _stext = .;
         *(.text.boot)
+        . = ALIGN(4K);
+        *(.text.signal_trampoline)
         *(.text .text.*)
         . = ALIGN(4K);
         _etext = .;

--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -98,8 +98,8 @@ SECTIONS {
     linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
     linkme_SYSCALL : { *(linkme_SYSCALL) }
     linkm2_SYSCALL : { *(linkm2_SYSCALL) }
-    linkme_ANY_TRAP : { *(linkme_ANY_TRAP) }
-    linkm2_ANY_TRAP : { *(linkm2_ANY_TRAP) }
+    linkme_POST_TRAP : { *(linkme_POST_TRAP) }
+    linkm2_POST_TRAP : { *(linkm2_POST_TRAP) }
     axns_resource : { *(axns_resource) }
 }
 INSERT AFTER .tbss;

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -21,9 +21,19 @@ impl TrapFrame {
         self.r[0] as _
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, a0: usize) {
+        self.r[0] = a0 as _;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.r[1] as _
+    }
+
+    /// Sets the 1st syscall argument.
+    pub const fn set_arg1(&mut self, a1: usize) {
+        self.r[1] = a1 as _;
     }
 
     /// Gets the 2nd syscall argument.
@@ -31,9 +41,19 @@ impl TrapFrame {
         self.r[2] as _
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, a2: usize) {
+        self.r[2] = a2 as _;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.r[3] as _
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, a3: usize) {
+        self.r[3] = a3 as _;
     }
 
     /// Gets the 4th syscall argument.
@@ -41,9 +61,54 @@ impl TrapFrame {
         self.r[4] as _
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, a4: usize) {
+        self.r[4] = a4 as _;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.r[5] as _
+    }
+
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, a5: usize) {
+        self.r[5] = a5 as _;
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.elr as _
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.usp as _
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, pc: usize) {
+        self.elr = pc as _;
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, sp: usize) {
+        self.usp = sp as _;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.r[0] as _
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, r0: usize) {
+        self.r[0] = r0 as _;
+    }
+
+    /// Sets the return address.
+    pub const fn set_ra(&mut self, lr: usize) {
+        self.r[30] = lr as _;
     }
 }
 
@@ -82,29 +147,14 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.elr as _
+    /// Gets the trap frame.
+    pub const fn trap_frame(&self) -> &TrapFrame {
+        &self.0
     }
 
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.usp as _
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, pc: usize) {
-        self.0.elr = pc as _;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, sp: usize) {
-        self.0.usp = sp as _;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, r0: usize) {
-        self.0.r[0] = r0 as _;
+    /// Gets the trap frame mutably.
+    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
+        &mut self.0
     }
 
     /// Enters user space.
@@ -231,6 +281,16 @@ impl TaskContext {
         self.sp = kstack_top.as_usize() as u64;
         self.lr = entry as u64;
         // When under `uspace` feature, kernel will not use this register.
+        self.tpidr_el0 = tls_area.as_usize() as u64;
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.tpidr_el0 as usize)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tpidr_el0 = tls_area.as_usize() as u64;
     }
 

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -147,16 +147,6 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the trap frame.
-    pub const fn trap_frame(&self) -> &TrapFrame {
-        &self.0
-    }
-
-    /// Gets the trap frame mutably.
-    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
-        &mut self.0
-    }
-
     /// Enters user space.
     ///
     /// It restores the user registers and jumps to the user entry point

--- a/modules/axhal/src/arch/aarch64/mod.rs
+++ b/modules/axhal/src/arch/aarch64/mod.rs
@@ -150,3 +150,5 @@ pub fn cpu_init() {
     set_exception_vector_base(exception_vector_base as usize);
     unsafe { write_page_table_root0(0.into()) }; // disable low address access in EL1
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/aarch64/signal.S
+++ b/modules/axhal/src/arch/aarch64/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.balign 4
+.global start_signal_trampoline
+start_signal_trampoline:
+    mov x8, #139
+    svc #0

--- a/modules/axhal/src/arch/aarch64/trap.S
+++ b/modules/axhal/src/arch/aarch64/trap.S
@@ -63,18 +63,20 @@
     b       .Lexception_return
 .endm
 
-.macro HANDLE_SYNC
+.macro HANDLE_SYNC, source
 .p2align 7
     SAVE_REGS
     mov     x0, sp
+    mov     x1, \source
     bl      handle_sync_exception
     b       .Lexception_return
 .endm
 
-.macro HANDLE_IRQ
+.macro HANDLE_IRQ, source
 .p2align 7
     SAVE_REGS
     mov     x0, sp
+    mov     x1, \source
     bl      handle_irq_exception
     b       .Lexception_return
 .endm
@@ -90,14 +92,14 @@ exception_vector_base:
     INVALID_EXCP 3 0
 
     // current EL, with SP_ELx
-    HANDLE_SYNC
-    HANDLE_IRQ
+    HANDLE_SYNC 1
+    HANDLE_IRQ 1
     INVALID_EXCP 2 1
     INVALID_EXCP 3 1
 
     // lower EL, aarch64
-    HANDLE_SYNC
-    HANDLE_IRQ
+    HANDLE_SYNC 2
+    HANDLE_IRQ 2
     INVALID_EXCP 2 2
     INVALID_EXCP 3 2
 

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -39,7 +39,7 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 #[unsafe(no_mangle)]
 fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
-    handle_trap!(ANY_TRAP, tf, source as u8 >= 2);
+    crate::trap::handle_any_trap(tf, source as u8 >= 2);
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -121,5 +121,5 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
             );
         }
     }
-    handle_trap!(ANY_TRAP, tf, source as u8 >= 2);
+    crate::trap::handle_any_trap(tf, source as u8 >= 2);
 }

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -44,7 +44,7 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 #[unsafe(no_mangle)]
 fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
-    crate::trap::post_trap_handler(tf, source.is_from_user());
+    crate::trap::post_trap_callback(tf, source.is_from_user());
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -126,5 +126,5 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
             );
         }
     }
-    crate::trap::post_trap_handler(tf, source.is_from_user());
+    crate::trap::post_trap_callback(tf, source.is_from_user());
 }

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -27,6 +27,11 @@ enum TrapSource {
     LowerAArch64 = 2,
     LowerAArch32 = 3,
 }
+impl TrapSource {
+    fn is_from_user(&self) -> bool {
+        matches!(self, TrapSource::LowerAArch64 | TrapSource::LowerAArch32)
+    }
+}
 
 #[unsafe(no_mangle)]
 fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
@@ -39,7 +44,7 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 #[unsafe(no_mangle)]
 fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
-    crate::trap::post_trap_handler(tf, source as u8 >= 2);
+    crate::trap::post_trap_handler(tf, source.is_from_user());
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -121,5 +126,5 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
             );
         }
     }
-    crate::trap::post_trap_handler(tf, source as u8 >= 2);
+    crate::trap::post_trap_handler(tf, source.is_from_user());
 }

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -39,7 +39,7 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 #[unsafe(no_mangle)]
 fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
-    crate::trap::handle_any_trap(tf, source as u8 >= 2);
+    crate::trap::post_trap_handler(tf, source as u8 >= 2);
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -121,5 +121,5 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
             );
         }
     }
-    crate::trap::handle_any_trap(tf, source as u8 >= 2);
+    crate::trap::post_trap_handler(tf, source as u8 >= 2);
 }

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -37,8 +37,9 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 }
 
 #[unsafe(no_mangle)]
-fn handle_irq_exception(_tf: &TrapFrame) {
+fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
+    handle_trap!(ANY_TRAP, tf, source as u8 >= 2);
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -94,7 +95,7 @@ fn handle_data_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
 }
 
 #[unsafe(no_mangle)]
-fn handle_sync_exception(tf: &mut TrapFrame) {
+fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
     let esr = ESR_EL1.extract();
     let iss = esr.read(ESR_EL1::ISS);
     match esr.read_as_enum(ESR_EL1::EC) {
@@ -120,4 +121,5 @@ fn handle_sync_exception(tf: &mut TrapFrame) {
             );
         }
     }
+    handle_trap!(ANY_TRAP, tf, source as u8 >= 2);
 }

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -58,9 +58,19 @@ impl TrapFrame {
         self.regs.a0 as _
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, a0: usize) {
+        self.regs.a0 = a0;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.regs.a1 as _
+    }
+
+    /// Sets the 1st syscall argument.
+    pub const fn set_arg1(&mut self, a1: usize) {
+        self.regs.a1 = a1;
     }
 
     /// Gets the 2nd syscall argument.
@@ -68,9 +78,19 @@ impl TrapFrame {
         self.regs.a2 as _
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, a2: usize) {
+        self.regs.a2 = a2;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.regs.a3 as _
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, a3: usize) {
+        self.regs.a3 = a3;
     }
 
     /// Gets the 4th syscall argument.
@@ -78,9 +98,54 @@ impl TrapFrame {
         self.regs.a4 as _
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, a4: usize) {
+        self.regs.a4 = a4;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.regs.a5 as _
+    }
+
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, a5: usize) {
+        self.regs.a5 = a5;
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.era
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.regs.sp
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, pc: usize) {
+        self.era = pc;
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, sp: usize) {
+        self.regs.sp = sp;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.regs.a0 as _
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, a0: usize) {
+        self.regs.a0 = a0;
+    }
+
+    /// Sets the return address.
+    pub const fn set_ra(&mut self, ra: usize) {
+        self.regs.ra = ra;
     }
 }
 
@@ -113,29 +178,14 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.era
+    /// Gets the trap frame.
+    pub const fn trap_frame(&self) -> &TrapFrame {
+        &self.0
     }
 
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.regs.sp
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, pc: usize) {
-        self.0.era = pc;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, sp: usize) {
-        self.0.regs.sp = sp;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, a0: usize) {
-        self.0.regs.a0 = a0;
+    /// Gets the trap frame mutably.
+    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
+        &mut self.0
     }
 
     /// Enters user space.
@@ -153,7 +203,7 @@ impl UspaceContext {
         use loongArch64::register::era;
 
         super::disable_irqs();
-        era::set_pc(self.get_ip());
+        era::set_pc(self.0.ip());
 
         unsafe {
             core::arch::asm!(
@@ -219,6 +269,16 @@ impl TaskContext {
     pub fn init(&mut self, entry: usize, kstack_top: VirtAddr, tls_area: VirtAddr) {
         self.sp = kstack_top.as_usize();
         self.ra = entry;
+        self.tp = tls_area.as_usize();
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.tp)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tp = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -178,16 +178,6 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the trap frame.
-    pub const fn trap_frame(&self) -> &TrapFrame {
-        &self.0
-    }
-
-    /// Gets the trap frame mutably.
-    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
-        &mut self.0
-    }
-
     /// Enters user space.
     ///
     /// It restores the user registers and jumps to the user entry point

--- a/modules/axhal/src/arch/loongarch64/mod.rs
+++ b/modules/axhal/src/arch/loongarch64/mod.rs
@@ -210,3 +210,5 @@ pub fn cpu_init() {
     }
     set_exception_entry_base(exception_entry_base as usize);
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/loongarch64/signal.S
+++ b/modules/axhal/src/arch/loongarch64/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.balign 4
+.global start_signal_trampoline
+start_signal_trampoline:
+    li.w    $a7, 139
+    syscall 0

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -69,4 +69,6 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             );
         }
     }
+
+    handle_trap!(ANY_TRAP, tf, from_user);
 }

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -70,5 +70,5 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
         }
     }
 
-    crate::trap::post_trap_handler(tf, from_user);
+    crate::trap::post_trap_callback(tf, from_user);
 }

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -70,5 +70,5 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
         }
     }
 
-    crate::trap::handle_any_trap(tf, from_user);
+    crate::trap::post_trap_handler(tf, from_user);
 }

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -70,5 +70,5 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
         }
     }
 
-    handle_trap!(ANY_TRAP, tf, from_user);
+    crate::trap::handle_any_trap(tf, from_user);
 }

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -57,9 +57,19 @@ impl TrapFrame {
         self.regs.a0
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, a0: usize) {
+        self.regs.a0 = a0;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.regs.a1
+    }
+
+    /// Sets the 1th syscall argument.
+    pub const fn set_arg1(&mut self, a1: usize) {
+        self.regs.a1 = a1;
     }
 
     /// Gets the 2nd syscall argument.
@@ -67,9 +77,19 @@ impl TrapFrame {
         self.regs.a2
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, a2: usize) {
+        self.regs.a2 = a2;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.regs.a3
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, a3: usize) {
+        self.regs.a3 = a3;
     }
 
     /// Gets the 4th syscall argument.
@@ -77,15 +97,60 @@ impl TrapFrame {
         self.regs.a4
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, a4: usize) {
+        self.regs.a4 = a4;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.regs.a5
+    }
+
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, a5: usize) {
+        self.regs.a5 = a5;
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.sepc
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.regs.sp
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, pc: usize) {
+        self.sepc = pc;
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, sp: usize) {
+        self.regs.sp = sp;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.regs.a0
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, a0: usize) {
+        self.regs.a0 = a0;
+    }
+
+    /// Sets the return address.
+    pub const fn set_ra(&mut self, ra: usize) {
+        self.regs.ra = ra;
     }
 }
 
 /// Context to enter user space.
 #[cfg(feature = "uspace")]
-pub struct UspaceContext(TrapFrame);
+pub struct UspaceContext(pub TrapFrame);
 
 #[cfg(feature = "uspace")]
 impl UspaceContext {
@@ -115,29 +180,14 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.sepc
+    /// Gets the trap frame.
+    pub const fn trap_frame(&self) -> &TrapFrame {
+        &self.0
     }
 
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.regs.sp
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, pc: usize) {
-        self.0.sepc = pc;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, sp: usize) {
-        self.0.regs.sp = sp;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, a0: usize) {
-        self.0.regs.a0 = a0;
+    /// Gets the trap frame mutably.
+    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
+        &mut self.0
     }
 
     /// Enters user space.
@@ -244,6 +294,16 @@ impl TaskContext {
     pub fn init(&mut self, entry: usize, kstack_top: VirtAddr, tls_area: VirtAddr) {
         self.sp = kstack_top.as_usize();
         self.ra = entry;
+        self.tp = tls_area.as_usize();
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.tp)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tp = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -215,16 +215,6 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the trap frame.
-    pub const fn trap_frame(&self) -> &TrapFrame {
-        &self.0
-    }
-
-    /// Gets the trap frame mutably.
-    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
-        &mut self.0
-    }
-
     /// Enters user space.
     ///
     /// It restores the user registers and jumps to the user entry point

--- a/modules/axhal/src/arch/riscv/mod.rs
+++ b/modules/axhal/src/arch/riscv/mod.rs
@@ -119,3 +119,5 @@ pub fn cpu_init() {
     }
     set_trap_vector_base(trap_vector_base as usize);
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/riscv/signal.S
+++ b/modules/axhal/src/arch/riscv/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.balign 4
+.global start_signal_trampoline
+start_signal_trampoline:
+    li a7, 139
+    ecall

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -60,7 +60,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
-        crate::trap::handle_any_trap(tf, from_user);
+        crate::trap::post_trap_handler(tf, from_user);
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -60,6 +60,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
+        handle_trap!(ANY_TRAP, tf, from_user);
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -60,7 +60,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
-        handle_trap!(ANY_TRAP, tf, from_user);
+        crate::trap::handle_any_trap(tf, from_user);
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -60,7 +60,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
-        crate::trap::post_trap_handler(tf, from_user);
+        crate::trap::post_trap_callback(tf, from_user);
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -39,9 +39,19 @@ impl TrapFrame {
         self.rdi as _
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, rdi: usize) {
+        self.rdi = rdi as _;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.rsi as _
+    }
+
+    /// Sets the 1st syscall argument.
+    pub const fn set_arg1(&mut self, rsi: usize) {
+        self.rsi = rsi as _;
     }
 
     /// Gets the 2nd syscall argument.
@@ -49,9 +59,19 @@ impl TrapFrame {
         self.rdx as _
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, rdx: usize) {
+        self.rdx = rdx as _;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.r10 as _
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, r10: usize) {
+        self.r10 = r10 as _;
     }
 
     /// Gets the 4th syscall argument.
@@ -59,14 +79,66 @@ impl TrapFrame {
         self.r8 as _
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, r8: usize) {
+        self.r8 = r8 as _;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.r9 as _
     }
 
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, r9: usize) {
+        self.r9 = r9 as _;
+    }
+
     /// Whether the trap is from userspace.
     pub const fn is_user(&self) -> bool {
         self.cs & 0b11 == 3
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.rip as _
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.rsp as _
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, rip: usize) {
+        self.rip = rip as _;
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, rsp: usize) {
+        self.rsp = rsp as _;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.rax as _
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, rax: usize) {
+        self.rax = rax as _;
+    }
+
+    /// Sets the return address.
+    ///
+    /// On x86_64, return address is stored in stack, so we need to modify the
+    /// stack in order to change the return address. This function uses a
+    /// separate name (rather than `set_ra`) to avoid confusion and misuse.
+    pub fn write_ra(&mut self, addr: usize) {
+        self.rsp -= 8;
+        unsafe {
+            core::ptr::write(self.rsp as *mut usize, addr);
+        }
     }
 }
 
@@ -110,29 +182,14 @@ impl UspaceContext {
         Self(tf)
     }
 
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.rip as _
+    /// Gets the trap frame.
+    pub const fn trap_frame(&self) -> &TrapFrame {
+        &self.0
     }
 
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.rsp as _
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, rip: usize) {
-        self.0.rip = rip as _;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, rsp: usize) {
-        self.0.rsp = rsp as _;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, rax: usize) {
-        self.0.rax = rax as _;
+    /// Gets the trap frame mutably.
+    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
+        &mut self.0
     }
 
     /// Enters user space.
@@ -322,6 +379,16 @@ impl TaskContext {
             self.rsp = frame_ptr as u64;
         }
         self.kstack_top = kstack_top;
+        self.fs_base = tls_area.as_usize();
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.fs_base)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.fs_base = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -114,11 +114,6 @@ impl TrapFrame {
         self.rip = rip as _;
     }
 
-    /// Gets the stack pointer.
-    pub const fn sp(&self) -> usize {
-        self.rsp as _
-    }
-
     /// Sets the stack pointer.
     pub const fn set_sp(&mut self, rsp: usize) {
         self.rsp = rsp as _;

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -182,16 +182,6 @@ impl UspaceContext {
         Self(tf)
     }
 
-    /// Gets the trap frame.
-    pub const fn trap_frame(&self) -> &TrapFrame {
-        &self.0
-    }
-
-    /// Gets the trap frame mutably.
-    pub fn trap_frame_mut(&mut self) -> &mut TrapFrame {
-        &mut self.0
-    }
-
     /// Enters user space.
     ///
     /// It restores the user registers and jumps to the user entry point

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -133,3 +133,5 @@ pub fn cpu_init() {
     #[cfg(feature = "uspace")]
     init_syscall();
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/x86_64/signal.S
+++ b/modules/axhal/src/arch/x86_64/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.code64
+.global start_signal_trampoline
+start_signal_trampoline:
+    mov rax, 0xf
+    syscall

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -32,7 +32,7 @@ syscall_entry:
 
     mov     rdi, rsp
     mov     rsi, 1 // is_user
-    call    handle_any_trap
+    call    post_trap_handler
 
     pop     rax
     pop     rcx

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -32,7 +32,7 @@ syscall_entry:
 
     mov     rdi, rsp
     mov     rsi, 1 // is_user
-    call    any_trap_handler
+    call    handle_any_trap
 
     pop     rax
     pop     rcx

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -32,7 +32,7 @@ syscall_entry:
 
     mov     rdi, rsp
     mov     rsi, 1 // is_user
-    call    post_trap_handler
+    call    post_trap_callback
 
     pop     rax
     pop     rcx

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -30,6 +30,10 @@ syscall_entry:
     mov     rdi, rsp
     call    x86_syscall_handler
 
+    mov     rdi, rsp
+    mov     rsi, 1 // is_user
+    call    any_trap_handler
+
     pop     rax
     pop     rcx
     pop     rdx

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -56,12 +56,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
-    any_trap_handler(tf, tf.is_user());
-}
-
-#[unsafe(no_mangle)]
-fn any_trap_handler(tf: &mut TrapFrame, is_user: bool) {
-    handle_trap!(ANY_TRAP, tf, is_user);
+    crate::trap::handle_any_trap(tf, tf.is_user());
 }
 
 fn vec_to_str(vec: u64) -> &'static str {

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -56,7 +56,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
-    crate::trap::post_trap_handler(tf, tf.is_user());
+    crate::trap::post_trap_callback(tf, tf.is_user());
 }
 
 fn vec_to_str(vec: u64) -> &'static str {

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -56,7 +56,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
-    crate::trap::handle_any_trap(tf, tf.is_user());
+    crate::trap::post_trap_handler(tf, tf.is_user());
 }
 
 fn vec_to_str(vec: u64) -> &'static str {

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -56,6 +56,12 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
+    any_trap_handler(tf, tf.is_user());
+}
+
+#[unsafe(no_mangle)]
+fn any_trap_handler(tf: &mut TrapFrame, is_user: bool) {
+    handle_trap!(ANY_TRAP, tf, is_user);
 }
 
 fn vec_to_str(vec: u64) -> &'static str {

--- a/modules/axhal/src/trap.rs
+++ b/modules/axhal/src/trap.rs
@@ -18,7 +18,7 @@ pub static PAGE_FAULT: [fn(VirtAddr, MappingFlags, bool) -> bool];
 
 /// A slice of abitrary trap handlers.
 #[def_trap_handler]
-pub static ANY_TRAP: [fn(&mut TrapFrame, bool) -> bool];
+pub static ANY_TRAP: [fn(&mut TrapFrame, bool)];
 
 /// A slice of syscall handler functions.
 #[cfg(feature = "uspace")]
@@ -39,6 +39,13 @@ macro_rules! handle_trap {
             false
         }
     }}
+}
+
+#[unsafe(no_mangle)]
+pub(crate) fn handle_any_trap(tf: &mut TrapFrame, from_user: bool) {
+    for handler in crate::trap::ANY_TRAP.iter() {
+        handler(tf, from_user);
+    }
 }
 
 /// Call the external syscall handler.

--- a/modules/axhal/src/trap.rs
+++ b/modules/axhal/src/trap.rs
@@ -16,14 +16,14 @@ pub static IRQ: [fn(usize) -> bool];
 #[def_trap_handler]
 pub static PAGE_FAULT: [fn(VirtAddr, MappingFlags, bool) -> bool];
 
-/// A slice of handlers to be invoked after a trap.
-#[def_trap_handler]
-pub static POST_TRAP: [fn(&mut TrapFrame, bool)];
-
 /// A slice of syscall handler functions.
 #[cfg(feature = "uspace")]
 #[def_trap_handler]
 pub static SYSCALL: [fn(&mut TrapFrame, usize) -> isize];
+
+/// A slice of callbacks to be invoked after a trap.
+#[linkme::distributed_slice]
+pub static POST_TRAP: [fn(&mut TrapFrame, bool)];
 
 #[allow(unused_macros)]
 macro_rules! handle_trap {
@@ -42,9 +42,9 @@ macro_rules! handle_trap {
 }
 
 #[unsafe(no_mangle)]
-pub(crate) fn post_trap_handler(tf: &mut TrapFrame, from_user: bool) {
-    for handler in crate::trap::POST_TRAP.iter() {
-        handler(tf, from_user);
+pub(crate) fn post_trap_callback(tf: &mut TrapFrame, from_user: bool) {
+    for cb in crate::trap::POST_TRAP.iter() {
+        cb(tf, from_user);
     }
 }
 

--- a/modules/axhal/src/trap.rs
+++ b/modules/axhal/src/trap.rs
@@ -4,10 +4,9 @@ use linkme::distributed_slice as def_trap_handler;
 use memory_addr::VirtAddr;
 use page_table_entry::MappingFlags;
 
-#[cfg(feature = "uspace")]
-use crate::arch::TrapFrame;
-
 pub use linkme::distributed_slice as register_trap_handler;
+
+use crate::arch::TrapFrame;
 
 /// A slice of IRQ handler functions.
 #[def_trap_handler]
@@ -17,10 +16,14 @@ pub static IRQ: [fn(usize) -> bool];
 #[def_trap_handler]
 pub static PAGE_FAULT: [fn(VirtAddr, MappingFlags, bool) -> bool];
 
+/// A slice of abitrary trap handlers.
+#[def_trap_handler]
+pub static ANY_TRAP: [fn(&mut TrapFrame, bool) -> bool];
+
 /// A slice of syscall handler functions.
 #[cfg(feature = "uspace")]
 #[def_trap_handler]
-pub static SYSCALL: [fn(&TrapFrame, usize) -> isize];
+pub static SYSCALL: [fn(&mut TrapFrame, usize) -> isize];
 
 #[allow(unused_macros)]
 macro_rules! handle_trap {
@@ -40,6 +43,6 @@ macro_rules! handle_trap {
 
 /// Call the external syscall handler.
 #[cfg(feature = "uspace")]
-pub(crate) fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
+pub(crate) fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
     SYSCALL[0](tf, syscall_num)
 }

--- a/modules/axhal/src/trap.rs
+++ b/modules/axhal/src/trap.rs
@@ -16,9 +16,9 @@ pub static IRQ: [fn(usize) -> bool];
 #[def_trap_handler]
 pub static PAGE_FAULT: [fn(VirtAddr, MappingFlags, bool) -> bool];
 
-/// A slice of abitrary trap handlers.
+/// A slice of handlers to be invoked after a trap.
 #[def_trap_handler]
-pub static ANY_TRAP: [fn(&mut TrapFrame, bool)];
+pub static POST_TRAP: [fn(&mut TrapFrame, bool)];
 
 /// A slice of syscall handler functions.
 #[cfg(feature = "uspace")]
@@ -42,8 +42,8 @@ macro_rules! handle_trap {
 }
 
 #[unsafe(no_mangle)]
-pub(crate) fn handle_any_trap(tf: &mut TrapFrame, from_user: bool) {
-    for handler in crate::trap::ANY_TRAP.iter() {
+pub(crate) fn post_trap_handler(tf: &mut TrapFrame, from_user: bool) {
+    for handler in crate::trap::POST_TRAP.iter() {
         handler(tf, from_user);
     }
 }

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -394,6 +394,10 @@ impl AddrSpace {
                 .areas
                 .map(new_area, &mut new_aspace.pt, false)
                 .map_err(mapping_err_to_ax_err)?;
+
+            if matches!(backend, Backend::Linear { .. }) {
+                continue;
+            }
             // Copy data from old memory area to new memory area.
             for vaddr in
                 PageIter4K::new(area.start(), area.end()).expect("Failed to create page iterator")


### PR DESCRIPTION
## Description  

This PR adds support for signal handling, which includes:

- Refactoring `UspaceContext` & `TrapFrame` so that more registers (including argx, retval, ra) are exposed
- Reserving a page as signal trampoline during linking
- Adding generic trap handling to handle any trap, allowing us to capture the returning from kernel to uspace
- Fixing `AddrSpace`: data of linear mapping should not be copied in `clone_or_err`

## How to Test  

Test results at [starry-next#signal](https://github.com/Mivik/starry-next/tree/signal)

| riscv | x86_64 | loongarch64 |
|-|-|-|
|![image](https://github.com/user-attachments/assets/245728ea-a5de-4f1a-9190-17f4f564fd2b)|![image](https://github.com/user-attachments/assets/beb76f52-18a8-4ec2-a39c-6526f20425af)|![屏幕截图_20250327_100745](https://github.com/user-attachments/assets/6b363369-f761-4cf5-8628-088723cf9beb)|
