### PR TITLE
fix fflush_exit

### DIFF
--- a/api/arceos_posix_api/src/imp/fd_ops.rs
+++ b/api/arceos_posix_api/src/imp/fd_ops.rs
@@ -65,9 +65,6 @@ pub fn close_file_like(fd: c_int) -> LinuxResult {
 /// Close a file by `fd`.
 pub fn sys_close(fd: c_int) -> c_int {
     debug!("sys_close <= {}", fd);
-    if (0..=2).contains(&fd) {
-        return 0; // stdin, stdout, stderr
-    }
     syscall_body!(sys_close, close_file_like(fd).map(|_| 0))
 }
 


### PR DESCRIPTION
## Description  

Enable `sys_close` on `stdin`, `stdout`, and `stderr`.

Libc-test testcase [`fflush-exit`](https://github.com/oscomp/testsuits-for-oskernel/blob/2025_multiarch/libc-test/src/regression/fflush-exit.c#L27) allows to close `stdout`.

## Related Issues(If necessary)  

## Implementation Details  

## How to Test  
<!-- Provide step-by-step instructions on how to test your changes. Mention any dependencies, test cases, or commands that should be run. -->

> Tips: Please provide the **test results** of running testcases for [starry-next](https://github.com/oscomp/starry-next) on the commit corresponding to your PR. You can paste it here in the form of a screenshot, or provide a CI link to **a branch or fork of starry-next** for us to review.

## Additional Notes  
<!-- Add any extra information or context that reviewers should be aware of. -->
