### PR TITLE
fix ftello_unflushed_append

### DIFF
--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -66,6 +66,9 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
+            if iov.iov_len == 0 {
+                continue;
+            }
             let result = write_impl(fd, iov.iov_base, iov.iov_len)?;
             ret += result;
 


### PR DESCRIPTION
## Description  
<!-- Provide a brief summary of the changes you made and why they are necessary. -->

Libc-test testcase [ftello_unflushed_append](https://github.com/oscomp/testsuits-for-oskernel/blob/2025_multiarch/libc-test/src/regression/ftello-unflushed-append.c#L31) calls `sys_writev` with argument `count = 2`. The `iov_base` of the second `iov` is 0, leading `write_impl` to return `EFAULT`. Treat the error as `0` to fix it. 

## Related Issues(If necessary)  
<!-- Link related issues using `Fixes #issue_number` or `Closes #issue_number` syntax. -->  

## Implementation Details  
<!-- Describe key technical details or approaches used in this PR. If applicable, include relevant screenshots or logs. -->

## How to Test  
<!-- Provide step-by-step instructions on how to test your changes. Mention any dependencies, test cases, or commands that should be run. -->

> Tips: Please provide the **test results** of running testcases for [starry-next](https://github.com/oscomp/starry-next) on the commit corresponding to your PR. You can paste it here in the form of a screenshot, or provide a CI link to **a branch or fork of starry-next** for us to review.

## Additional Notes  
<!-- Add any extra information or context that reviewers should be aware of. -->
