### PR TITLE
feat(hal): improve context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "lwext4_rust"
 version = "0.2.0"
-source = "git+https://github.com/Azure-stars/lwext4_rust.git#d1561e971c37555428695b12b869ec938af5a058"
+source = "git+https://github.com/Azure-stars/lwext4_rust.git#2e56b0aa2680b210892a46375fefca2bdf6e2865"
 dependencies = [
  "log",
 ]

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -21,9 +21,19 @@ impl TrapFrame {
         self.r[0] as _
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, a0: usize) {
+        self.r[0] = a0 as _;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.r[1] as _
+    }
+
+    /// Sets the 1st syscall argument.
+    pub const fn set_arg1(&mut self, a1: usize) {
+        self.r[1] = a1 as _;
     }
 
     /// Gets the 2nd syscall argument.
@@ -31,9 +41,19 @@ impl TrapFrame {
         self.r[2] as _
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, a2: usize) {
+        self.r[2] = a2 as _;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.r[3] as _
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, a3: usize) {
+        self.r[3] = a3 as _;
     }
 
     /// Gets the 4th syscall argument.
@@ -41,9 +61,54 @@ impl TrapFrame {
         self.r[4] as _
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, a4: usize) {
+        self.r[4] = a4 as _;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.r[5] as _
+    }
+
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, a5: usize) {
+        self.r[5] = a5 as _;
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.elr as _
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, pc: usize) {
+        self.elr = pc as _;
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.usp as _
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, sp: usize) {
+        self.usp = sp as _;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.r[0] as _
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, r0: usize) {
+        self.r[0] = r0 as _;
+    }
+
+    /// Sets the return address.
+    pub const fn set_ra(&mut self, lr: usize) {
+        self.r[30] = lr as _;
     }
 }
 
@@ -80,31 +145,6 @@ impl UspaceContext {
     /// Creates a new context from the given [`TrapFrame`].
     pub const fn from(trap_frame: &TrapFrame) -> Self {
         Self(*trap_frame)
-    }
-
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.elr as _
-    }
-
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.usp as _
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, pc: usize) {
-        self.0.elr = pc as _;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, sp: usize) {
-        self.0.usp = sp as _;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, r0: usize) {
-        self.0.r[0] = r0 as _;
     }
 
     /// Enters user space.
@@ -155,6 +195,22 @@ impl UspaceContext {
                 options(noreturn),
             )
         }
+    }
+}
+
+#[cfg(feature = "uspace")]
+impl core::ops::Deref for UspaceContext {
+    type Target = TrapFrame;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "uspace")]
+impl core::ops::DerefMut for UspaceContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -231,6 +287,16 @@ impl TaskContext {
         self.sp = kstack_top.as_usize() as u64;
         self.lr = entry as u64;
         // When under `uspace` feature, kernel will not use this register.
+        self.tpidr_el0 = tls_area.as_usize() as u64;
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.tpidr_el0 as usize)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tpidr_el0 = tls_area.as_usize() as u64;
     }
 

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -81,9 +81,19 @@ impl TrapFrame {
         self.regs.a0
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, a0: usize) {
+        self.regs.a0 = a0;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.regs.a1
+    }
+
+    /// Sets the 1th syscall argument.
+    pub const fn set_arg1(&mut self, a1: usize) {
+        self.regs.a1 = a1;
     }
 
     /// Gets the 2nd syscall argument.
@@ -91,9 +101,19 @@ impl TrapFrame {
         self.regs.a2
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, a2: usize) {
+        self.regs.a2 = a2;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.regs.a3
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, a3: usize) {
+        self.regs.a3 = a3;
     }
 
     /// Gets the 4th syscall argument.
@@ -101,9 +121,54 @@ impl TrapFrame {
         self.regs.a4
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, a4: usize) {
+        self.regs.a4 = a4;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.regs.a5
+    }
+
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, a5: usize) {
+        self.regs.a5 = a5;
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.sepc
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, pc: usize) {
+        self.sepc = pc;
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.regs.sp
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, sp: usize) {
+        self.regs.sp = sp;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.regs.a0
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, a0: usize) {
+        self.regs.a0 = a0;
+    }
+
+    /// Sets the return address.
+    pub const fn set_ra(&mut self, ra: usize) {
+        self.regs.ra = ra;
     }
 }
 
@@ -150,31 +215,6 @@ impl UspaceContext {
         Self(*trap_frame)
     }
 
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.sepc
-    }
-
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.regs.sp
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, pc: usize) {
-        self.0.sepc = pc;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, sp: usize) {
-        self.0.regs.sp = sp;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, a0: usize) {
-        self.0.regs.a0 = a0;
-    }
-
     /// Enters user space.
     ///
     /// It restores the user registers and jumps to the user entry point
@@ -216,6 +256,22 @@ impl UspaceContext {
                 options(noreturn),
             )
         }
+    }
+}
+
+#[cfg(feature = "uspace")]
+impl core::ops::Deref for UspaceContext {
+    type Target = TrapFrame;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "uspace")]
+impl core::ops::DerefMut for UspaceContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -285,6 +341,16 @@ impl TaskContext {
     pub fn init(&mut self, entry: usize, kstack_top: VirtAddr, tls_area: VirtAddr) {
         self.sp = kstack_top.as_usize();
         self.ra = entry;
+        self.tp = tls_area.as_usize();
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.tp)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tp = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -39,9 +39,19 @@ impl TrapFrame {
         self.rdi as _
     }
 
+    /// Sets the 0th syscall argument.
+    pub const fn set_arg0(&mut self, rdi: usize) {
+        self.rdi = rdi as _;
+    }
+
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
         self.rsi as _
+    }
+
+    /// Sets the 1st syscall argument.
+    pub const fn set_arg1(&mut self, rsi: usize) {
+        self.rsi = rsi as _;
     }
 
     /// Gets the 2nd syscall argument.
@@ -49,9 +59,19 @@ impl TrapFrame {
         self.rdx as _
     }
 
+    /// Sets the 2nd syscall argument.
+    pub const fn set_arg2(&mut self, rdx: usize) {
+        self.rdx = rdx as _;
+    }
+
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
         self.r10 as _
+    }
+
+    /// Sets the 3rd syscall argument.
+    pub const fn set_arg3(&mut self, r10: usize) {
+        self.r10 = r10 as _;
     }
 
     /// Gets the 4th syscall argument.
@@ -59,14 +79,66 @@ impl TrapFrame {
         self.r8 as _
     }
 
+    /// Sets the 4th syscall argument.
+    pub const fn set_arg4(&mut self, r8: usize) {
+        self.r8 = r8 as _;
+    }
+
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
         self.r9 as _
     }
 
+    /// Sets the 5th syscall argument.
+    pub const fn set_arg5(&mut self, r9: usize) {
+        self.r9 = r9 as _;
+    }
+
     /// Whether the trap is from userspace.
     pub const fn is_user(&self) -> bool {
         self.cs & 0b11 == 3
+    }
+
+    /// Gets the instruction pointer.
+    pub const fn ip(&self) -> usize {
+        self.rip as _
+    }
+
+    /// Sets the instruction pointer.
+    pub const fn set_ip(&mut self, rip: usize) {
+        self.rip = rip as _;
+    }
+
+    /// Gets the stack pointer.
+    pub const fn sp(&self) -> usize {
+        self.rsp as _
+    }
+
+    /// Sets the stack pointer.
+    pub const fn set_sp(&mut self, rsp: usize) {
+        self.rsp = rsp as _;
+    }
+
+    /// Gets the return value register.
+    pub const fn retval(&self) -> usize {
+        self.rax as _
+    }
+
+    /// Sets the return value register.
+    pub const fn set_retval(&mut self, rax: usize) {
+        self.rax = rax as _;
+    }
+
+    /// Sets the return address.
+    ///
+    /// On x86_64, return address is stored in stack, so we need to modify the
+    /// stack in order to change the return address. This function uses a
+    /// separate name (rather than `set_ra`) to avoid confusion and misuse.
+    pub fn write_ra(&mut self, addr: usize) {
+        self.rsp -= 8;
+        unsafe {
+            core::ptr::write(self.rsp as *mut usize, addr);
+        }
     }
 }
 
@@ -110,31 +182,6 @@ impl UspaceContext {
         Self(tf)
     }
 
-    /// Gets the instruction pointer.
-    pub const fn get_ip(&self) -> usize {
-        self.0.rip as _
-    }
-
-    /// Gets the stack pointer.
-    pub const fn get_sp(&self) -> usize {
-        self.0.rsp as _
-    }
-
-    /// Sets the instruction pointer.
-    pub const fn set_ip(&mut self, rip: usize) {
-        self.0.rip = rip as _;
-    }
-
-    /// Sets the stack pointer.
-    pub const fn set_sp(&mut self, rsp: usize) {
-        self.0.rsp = rsp as _;
-    }
-
-    /// Sets the return value register.
-    pub const fn set_retval(&mut self, rax: usize) {
-        self.0.rax = rax as _;
-    }
-
     /// Enters user space.
     ///
     /// It restores the user registers and jumps to the user entry point
@@ -173,6 +220,22 @@ impl UspaceContext {
                 options(noreturn),
             )
         }
+    }
+}
+
+#[cfg(feature = "uspace")]
+impl core::ops::Deref for UspaceContext {
+    type Target = TrapFrame;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "uspace")]
+impl core::ops::DerefMut for UspaceContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -322,6 +385,16 @@ impl TaskContext {
             self.rsp = frame_ptr as u64;
         }
         self.kstack_top = kstack_top;
+        self.fs_base = tls_area.as_usize();
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> VirtAddr {
+        VirtAddr::from(self.fs_base)
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.fs_base = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -129,12 +129,12 @@ impl TrapFrame {
         self.rax = rax as _;
     }
 
-    /// Sets the return address.
+    /// Push the return address.
     ///
     /// On x86_64, return address is stored in stack, so we need to modify the
     /// stack in order to change the return address. This function uses a
     /// separate name (rather than `set_ra`) to avoid confusion and misuse.
-    pub fn write_ra(&mut self, addr: usize) {
+    pub fn push_ra(&mut self, addr: usize) {
         self.rsp -= 8;
         unsafe {
             core::ptr::write(self.rsp as *mut usize, addr);


### PR DESCRIPTION
## Description
This PR generally improves the public api on `TrapFrame`, `UspaceContext` and `TaskContext`.
- A set of helper functions are added to `TrapFrame`.
- `Deref` and `DerefMut` is implemented for `UspaceContext` to allow easier access to the underlying `TrapFrame`.
- `tls()` and `set_tls()` are added to `TaskContext`.

These code are extracted from #23 by @Mivik.

## Related Issues(If necessary)
- https://github.com/oscomp/starry-next/issues/5#issuecomment-2765277217
- https://github.com/oscomp/starry-next/discussions/30