### PR TITLE
fix fcntl

### DIFF
--- a/api/arceos_posix_api/src/imp/fd_ops.rs
+++ b/api/arceos_posix_api/src/imp/fd_ops.rs
@@ -130,6 +130,12 @@ pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> c_int {
                 get_file_like(fd)?.set_nonblocking(arg & (ctypes::O_NONBLOCK as usize) > 0)?;
                 Ok(0)
             }
+            ctypes::F_GETFL => match get_file_like(fd)?.stat()?.st_mode & 0o600 {
+                0o400 => Ok(ctypes::O_RDONLY as _),
+                0o200 => Ok(ctypes::O_WRONLY as _),
+                0o600 => Ok(ctypes::O_RDWR as _),
+                _ => Ok(0),
+            },
             _ => {
                 warn!("unsupported fcntl parameters: cmd {}", cmd);
                 Ok(0)


### PR DESCRIPTION
## Description  
<!-- Provide a brief summary of the changes you made and why they are necessary. -->

In glibc, [`tmpfile()`](https://github.com/oscomp/testsuits-for-oskernel/blob/b42d1671ee30db3a012d8f60f1d3daf900f0f8bf/libc-test/src/functional/ungetc.c#L22) calls [`__fcntl()`](https://github.com/bminor/glibc/blob/12a497c716f0a06be5946cabb8c3ec22a079771e/libio/iofdopen.c#L88) with `F_GETFL` to get file status by file description, which is not implemented before. 

## Related Issues(If necessary)  
<!-- Link related issues using `Fixes #issue_number` or `Closes #issue_number` syntax. -->  

## Implementation Details  
<!-- Describe key technical details or approaches used in this PR. If applicable, include relevant screenshots or logs. -->

## How to Test  
<!-- Provide step-by-step instructions on how to test your changes. Mention any dependencies, test cases, or commands that should be run. -->

> Tips: Please provide the **test results** of running testcases for [starry-next](https://github.com/oscomp/starry-next) on the commit corresponding to your PR. You can paste it here in the form of a screenshot, or provide a CI link to **a branch or fork of starry-next** for us to review.

## Additional Notes  
<!-- Add any extra information or context that reviewers should be aware of. -->
