### PR TITLE
feat: lock_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "axsync",
  "axtask",
  "kspin",
+ "lock_api",
  "rand",
 ]
 

--- a/modules/axsync/Cargo.toml
+++ b/modules/axsync/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 
 [dependencies]
 kspin = "0.1"
+lock_api = { version = "0.4", default-features = false }
 axtask = { workspace = true }
 
 [dev-dependencies]

--- a/modules/axsync/src/lib.rs
+++ b/modules/axsync/src/lib.rs
@@ -21,7 +21,7 @@ mod mutex;
 
 #[cfg(feature = "multitask")]
 #[doc(cfg(feature = "multitask"))]
-pub use self::mutex::{Mutex, MutexGuard};
+pub use self::mutex::{Mutex, MutexGuard, RawMutex};
 
 #[cfg(not(feature = "multitask"))]
 #[doc(cfg(not(feature = "multitask")))]

--- a/modules/axsync/src/mutex.rs
+++ b/modules/axsync/src/mutex.rs
@@ -1,74 +1,36 @@
 //! A naïve sleeping mutex.
 
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use axtask::{WaitQueue, current};
 
-/// A mutual exclusion primitive useful for protecting shared data, similar to
-/// [`std::sync::Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html).
+/// A [`lock_api::RawMutex`] implementation.
 ///
 /// When the mutex is locked, the current task will block and be put into the
 /// wait queue. When the mutex is unlocked, all tasks waiting on the queue
 /// will be woken up.
-pub struct Mutex<T: ?Sized> {
+pub struct RawMutex {
     wq: WaitQueue,
     owner_id: AtomicU64,
-    data: UnsafeCell<T>,
 }
 
-/// A guard that provides mutable data access.
-///
-/// When the guard falls out of scope it will release the lock.
-pub struct MutexGuard<'a, T: ?Sized + 'a> {
-    lock: &'a Mutex<T>,
-    data: *mut T,
-}
-
-// Same unsafe impls as `std::sync::Mutex`
-unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
-unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
-
-impl<T> Mutex<T> {
-    /// Creates a new [`Mutex`] wrapping the supplied data.
+impl RawMutex {
+    /// Creates a [`RawMutex`].
     #[inline(always)]
-    pub const fn new(data: T) -> Self {
+    pub const fn new() -> Self {
         Self {
             wq: WaitQueue::new(),
             owner_id: AtomicU64::new(0),
-            data: UnsafeCell::new(data),
         }
-    }
-
-    /// Consumes this [`Mutex`] and unwraps the underlying data.
-    #[inline(always)]
-    pub fn into_inner(self) -> T {
-        // We know statically that there are no outstanding references to
-        // `self` so there's no need to lock.
-        let Mutex { data, .. } = self;
-        data.into_inner()
     }
 }
 
-impl<T: ?Sized> Mutex<T> {
-    /// Returns `true` if the lock is currently held.
-    ///
-    /// # Safety
-    ///
-    /// This function provides no synchronization guarantees and so its result should be considered 'out of date'
-    /// the instant it is called. Do not use it for synchronization purposes. However, it may be useful as a heuristic.
-    #[inline(always)]
-    pub fn is_locked(&self) -> bool {
-        self.owner_id.load(Ordering::Relaxed) != 0
-    }
+unsafe impl lock_api::RawMutex for RawMutex {
+    const INIT: Self = RawMutex::new();
 
-    /// Locks the [`Mutex`] and returns a guard that permits access to the inner data.
-    ///
-    /// The returned value may be dereferenced for data access
-    /// and the lock will be dropped when the guard falls out of scope.
-    pub fn lock(&self) -> MutexGuard<T> {
+    type GuardMarker = lock_api::GuardSend;
+
+    fn lock(&self) {
         let current_id = current().id().as_u64();
         loop {
             // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
@@ -92,40 +54,18 @@ impl<T: ?Sized> Mutex<T> {
                 }
             }
         }
-        MutexGuard {
-            lock: self,
-            data: unsafe { &mut *self.data.get() },
-        }
     }
 
-    /// Try to lock this [`Mutex`], returning a lock guard if successful.
-    #[inline(always)]
-    pub fn try_lock(&self) -> Option<MutexGuard<T>> {
+    fn try_lock(&self) -> bool {
         let current_id = current().id().as_u64();
         // The reason for using a strong compare_exchange is explained here:
         // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
-        if self
-            .owner_id
+        self.owner_id
             .compare_exchange(0, current_id, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
-        {
-            Some(MutexGuard {
-                lock: self,
-                data: unsafe { &mut *self.data.get() },
-            })
-        } else {
-            None
-        }
     }
 
-    /// Force unlock the [`Mutex`].
-    ///
-    /// # Safety
-    ///
-    /// This is *extremely* unsafe if the lock is not held by the current
-    /// thread. However, this can be useful in some instances for exposing
-    /// the lock to FFI that doesn’t know how to deal with RAII.
-    pub unsafe fn force_unlock(&self) {
+    unsafe fn unlock(&self) {
         let owner_id = self.owner_id.swap(0, Ordering::Release);
         assert_eq!(
             owner_id,
@@ -136,66 +76,15 @@ impl<T: ?Sized> Mutex<T> {
         self.wq.notify_one(true);
     }
 
-    /// Returns a mutable reference to the underlying data.
-    ///
-    /// Since this call borrows the [`Mutex`] mutably, and a mutable reference is guaranteed to be exclusive in
-    /// Rust, no actual locking needs to take place -- the mutable borrow statically guarantees no locks exist. As
-    /// such, this is a 'zero-cost' operation.
-    #[inline(always)]
-    pub fn get_mut(&mut self) -> &mut T {
-        // We know statically that there are no other references to `self`, so
-        // there's no need to lock the inner mutex.
-        unsafe { &mut *self.data.get() }
+    fn is_locked(&self) -> bool {
+        self.owner_id.load(Ordering::Relaxed) != 0
     }
 }
 
-impl<T: Default> Default for Mutex<T> {
-    #[inline(always)]
-    fn default() -> Self {
-        Self::new(Default::default())
-    }
-}
-
-impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.try_lock() {
-            Some(guard) => write!(f, "Mutex {{ data: ")
-                .and_then(|()| (*guard).fmt(f))
-                .and_then(|()| write!(f, "}}")),
-            None => write!(f, "Mutex {{ <locked> }}"),
-        }
-    }
-}
-
-impl<T: ?Sized> Deref for MutexGuard<'_, T> {
-    type Target = T;
-    #[inline(always)]
-    fn deref(&self) -> &T {
-        // We know statically that only we are referencing data
-        unsafe { &*self.data }
-    }
-}
-
-impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut T {
-        // We know statically that only we are referencing data
-        unsafe { &mut *self.data }
-    }
-}
-
-impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
-    }
-}
-
-impl<T: ?Sized> Drop for MutexGuard<'_, T> {
-    /// The dropping of the [`MutexGuard`] will release the lock it was created from.
-    fn drop(&mut self) {
-        unsafe { self.lock.force_unlock() }
-    }
-}
+/// An alias of [`lock_api::Mutex`].
+pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
+/// An alias of [`lock_api::MutexGuard`].
+pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Description
This PR adapts axsync::Mutex with [lock_api](https://docs.rs/lock_api).

It adds the `RawMutex` type and allows the use of more complete APIs provided by lock_api, such as `lock_arc`, `map`, etc.

## Additional notes
1. Maybe we should also adapt [kspin](https://docs.rs/kspin/latest/kspin/) to lock_api.
2. Perhaps we can further implement more traits in lock_api later, such as `RawMutexTimed` or `RawRwLock`.
3. [spin](https://docs.rs/spin) is compatible with lock_api.