### PR TITLE
Fix ip bump and tls isolation for hal

### DIFF
--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -9,6 +9,8 @@ pub struct TrapFrame {
     pub r: [u64; 31],
     /// User Stack Pointer (SP_EL0).
     pub usp: u64,
+    /// Software Thread ID Register (TPIDR_EL0).
+    pub tpidr: u64,
     /// Exception Link Register (ELR_EL1).
     pub elr: u64,
     /// Saved Process Status Register (SPSR_EL1).
@@ -110,6 +112,16 @@ impl TrapFrame {
     pub const fn set_ra(&mut self, lr: usize) {
         self.r[30] = lr as _;
     }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> usize {
+        self.tpidr as _
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls: usize) {
+        self.tpidr = tls as _;
+    }
 }
 
 /// Context to enter user space.
@@ -132,6 +144,7 @@ impl UspaceContext {
         Self(TrapFrame {
             r: regs,
             usp: ustack_top.as_usize() as _,
+            tpidr: 0,
             elr: entry as _,
             spsr: (SPSR_EL1::M::EL0t
                 + SPSR_EL1::D::Masked
@@ -168,12 +181,19 @@ impl UspaceContext {
             core::arch::asm!(
                 "
                 mov     sp, x1
-                ldp     x30, x9, [x0, 30 * 8]
-                ldp     x10, x11, [x0, 32 * 8]
-                msr     sp_el0, x9
-                msr     elr_el1, x10
-                msr     spsr_el1, x11
 
+                // backup kernel tpidr_el0
+                mrs     x1, tpidr_el0
+                msr     tpidrro_el0, x1
+
+                ldp     x11, x12, [x0, 33 * 8]
+                ldp     x9, x10, [x0, 31 * 8]
+                msr     sp_el0, x9
+                msr     tpidr_el0, x10
+                msr     elr_el1, x11
+                msr     spsr_el1, x12
+
+                ldr     x30, [x0, 30 * 8]
                 ldp     x28, x29, [x0, 28 * 8]
                 ldp     x26, x27, [x0, 26 * 8]
                 ldp     x24, x25, [x0, 24 * 8]
@@ -249,7 +269,6 @@ impl FpState {
 #[derive(Debug, Default)]
 pub struct TaskContext {
     pub sp: u64,
-    pub tpidr_el0: u64,
     pub r19: u64,
     pub r20: u64,
     pub r21: u64,
@@ -262,6 +281,7 @@ pub struct TaskContext {
     pub r28: u64,
     pub r29: u64,
     pub lr: u64, // r30
+    pub tpidr_el0: u64,
     /// The `ttbr0_el1` register value, i.e., the page table root.
     #[cfg(feature = "uspace")]
     pub ttbr0_el1: memory_addr::PhysAddr,
@@ -290,16 +310,6 @@ impl TaskContext {
         self.tpidr_el0 = tls_area.as_usize() as u64;
     }
 
-    /// Gets the TLS area.
-    pub fn tls(&self) -> VirtAddr {
-        VirtAddr::from(self.tpidr_el0 as usize)
-    }
-
-    /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls_area: VirtAddr) {
-        self.tpidr_el0 = tls_area.as_usize() as u64;
-    }
-
     /// Changes the page table root for user space (`ttbr0_el1` register for aarch64 in el1 level).
     ///
     /// If not set, it means that this task is a kernel task and only `ttbr1_el1` register will be used.
@@ -313,6 +323,11 @@ impl TaskContext {
     /// It first saves the current task's context from CPU to this place, and then
     /// restores the next task's context from `next_ctx` to CPU.
     pub fn switch_to(&mut self, next_ctx: &Self) {
+        #[cfg(feature = "tls")]
+        {
+            self.tpidr_el0 = super::read_thread_pointer() as _;
+            unsafe { super::write_thread_pointer(next_ctx.tpidr_el0 as _) };
+        }
         #[cfg(feature = "fp_simd")]
         self.fp_state.switch_to(&next_ctx.fp_state);
         #[cfg(feature = "uspace")]
@@ -327,32 +342,32 @@ impl TaskContext {
 
 #[naked]
 unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task: &TaskContext) {
-    naked_asm!(
-        "
-        // save old context (callee-saved registers)
-        stp     x29, x30, [x0, 12 * 8]
-        stp     x27, x28, [x0, 10 * 8]
-        stp     x25, x26, [x0, 8 * 8]
-        stp     x23, x24, [x0, 6 * 8]
-        stp     x21, x22, [x0, 4 * 8]
-        stp     x19, x20, [x0, 2 * 8]
-        mov     x19, sp
-        mrs     x20, tpidr_el0
-        stp     x19, x20, [x0]
+    unsafe {
+        naked_asm!(
+            "
+            // save old context (callee-saved registers)
+            stp     x29, x30, [x0, 11 * 8]
+            stp     x27, x28, [x0, 9 * 8]
+            stp     x25, x26, [x0, 7 * 8]
+            stp     x23, x24, [x0, 5 * 8]
+            stp     x21, x22, [x0, 3 * 8]
+            stp     x19, x20, [x0, 1 * 8]
+            mov     x19, sp
+            str     x19, [x0]
 
-        // restore new context
-        ldp     x19, x20, [x1]
-        mov     sp, x19
-        msr     tpidr_el0, x20
-        ldp     x19, x20, [x1, 2 * 8]
-        ldp     x21, x22, [x1, 4 * 8]
-        ldp     x23, x24, [x1, 6 * 8]
-        ldp     x25, x26, [x1, 8 * 8]
-        ldp     x27, x28, [x1, 10 * 8]
-        ldp     x29, x30, [x1, 12 * 8]
+            // restore new context
+            ldr     x19, [x1]
+            mov     sp, x19
+            ldp     x19, x20, [x1, 1 * 8]
+            ldp     x21, x22, [x1, 3 * 8]
+            ldp     x23, x24, [x1, 5 * 8]
+            ldp     x25, x26, [x1, 7 * 8]
+            ldp     x27, x28, [x1, 9 * 8]
+            ldp     x29, x30, [x1, 11 * 8]
 
-        ret",
-    )
+            ret",
+        )
+    }
 }
 
 #[naked]

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -259,7 +259,7 @@ impl FpState {
 ///
 /// - Callee-saved registers
 /// - Stack pointer register
-/// - Thread pointer register (for thread-local storage, currently unsupported)
+/// - Thread pointer register (for kernel space thread-local storage)
 /// - FP/SIMD registers
 ///
 /// On context switch, current task saves its context from CPU to memory,
@@ -281,6 +281,7 @@ pub struct TaskContext {
     pub r28: u64,
     pub r29: u64,
     pub lr: u64, // r30
+    /// Thread pointer
     pub tpidr_el0: u64,
     /// The `ttbr0_el1` register value, i.e., the page table root.
     #[cfg(feature = "uspace")]

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -114,12 +114,12 @@ impl TrapFrame {
     }
 
     /// Gets the TLS area.
-    pub fn tls(&self) -> usize {
+    pub const fn tls(&self) -> usize {
         self.tpidr as _
     }
 
     /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls: usize) {
+    pub const fn set_tls(&mut self, tls: usize) {
         self.tpidr = tls as _;
     }
 }

--- a/modules/axhal/src/arch/aarch64/trap.S
+++ b/modules/axhal/src/arch/aarch64/trap.S
@@ -1,5 +1,5 @@
 .macro SAVE_REGS
-    sub     sp, sp, 34 * 8
+    sub     sp, sp, {trapframe_size}
     stp     x0, x1, [sp]
     stp     x2, x3, [sp, 2 * 8]
     stp     x4, x5, [sp, 4 * 8]
@@ -15,13 +15,19 @@
     stp     x24, x25, [sp, 24 * 8]
     stp     x26, x27, [sp, 26 * 8]
     stp     x28, x29, [sp, 28 * 8]
+    str     x30, [sp, 30 * 8]
 
     mrs     x9, sp_el0
-    mrs     x10, elr_el1
-    mrs     x11, spsr_el1
-    stp     x30, x9, [sp, 30 * 8]
-    stp     x10, x11, [sp, 32 * 8]
-    
+    mrs     x10, tpidr_el0
+    mrs     x11, elr_el1
+    mrs     x12, spsr_el1
+    stp     x9, x10, [sp, 31 * 8]
+    stp     x11, x12, [sp, 33 * 8]
+
+    # restore kernel tpidr_el0
+    mrs     x1, tpidrro_el0
+    msr     tpidr_el0, x1
+
     # We may have interrupted userspace, or a guest, or exit-from or 
     # return-to either of those. So we can't trust sp_el0, and need to
     # restore it.
@@ -29,12 +35,18 @@
 .endm
 
 .macro RESTORE_REGS
-    ldp     x10, x11, [sp, 32 * 8]
-    ldp     x30, x9, [sp, 30 * 8]
-    msr     sp_el0, x9
-    msr     elr_el1, x10
-    msr     spsr_el1, x11
+    # backup kernel tpidr_el0
+    mrs     x1, tpidr_el0
+    msr     tpidrro_el0, x1
 
+    ldp     x11, x12, [sp, 33 * 8]
+    ldp     x9, x10, [sp, 31 * 8]
+    msr     sp_el0, x9
+    msr     tpidr_el0, x10
+    msr     elr_el1, x11
+    msr     spsr_el1, x12
+
+    ldr     x30, [sp, 30 * 8]
     ldp     x28, x29, [sp, 28 * 8]
     ldp     x26, x27, [sp, 26 * 8]
     ldp     x24, x25, [sp, 24 * 8]
@@ -50,7 +62,7 @@
     ldp     x4, x5, [sp, 4 * 8]
     ldp     x2, x3, [sp, 2 * 8]
     ldp     x0, x1, [sp]
-    add     sp, sp, 34 * 8
+    add     sp, sp, {trapframe_size}
 .endm
 
 .macro INVALID_EXCP, kind, source

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -6,7 +6,11 @@ use tock_registers::interfaces::Readable;
 
 use super::TrapFrame;
 
-global_asm!(include_str!("trap.S"), cache_current_task_ptr = sym crate::cpu::cache_current_task_ptr);
+global_asm!(
+    include_str!("trap.S"),
+    trapframe_size = const core::mem::size_of::<TrapFrame>(),
+    cache_current_task_ptr = sym crate::cpu::cache_current_task_ptr,
+);
 
 #[repr(u8)]
 #[derive(Debug)]

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -252,7 +252,7 @@ impl core::ops::DerefMut for UspaceContext {
 ///
 /// - Callee-saved registers
 /// - Stack pointer register
-/// - Thread pointer register (for thread-local storage, currently unsupported)
+/// - Thread pointer register (for kernel space thread-local storage)
 /// - FP/SIMD registers
 ///
 /// On context switch, current task saves its context from CPU to memory,

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -55,7 +55,7 @@ pub struct TrapFrame {
 impl TrapFrame {
     /// Gets the 0th syscall argument.
     pub const fn arg0(&self) -> usize {
-        self.regs.a0 as _
+        self.regs.a0
     }
 
     /// Sets the 0th syscall argument.
@@ -65,7 +65,7 @@ impl TrapFrame {
 
     /// Gets the 1st syscall argument.
     pub const fn arg1(&self) -> usize {
-        self.regs.a1 as _
+        self.regs.a1
     }
 
     /// Sets the 1st syscall argument.
@@ -75,7 +75,7 @@ impl TrapFrame {
 
     /// Gets the 2nd syscall argument.
     pub const fn arg2(&self) -> usize {
-        self.regs.a2 as _
+        self.regs.a2
     }
 
     /// Sets the 2nd syscall argument.
@@ -85,7 +85,7 @@ impl TrapFrame {
 
     /// Gets the 3rd syscall argument.
     pub const fn arg3(&self) -> usize {
-        self.regs.a3 as _
+        self.regs.a3
     }
 
     /// Sets the 3rd syscall argument.
@@ -95,7 +95,7 @@ impl TrapFrame {
 
     /// Gets the 4th syscall argument.
     pub const fn arg4(&self) -> usize {
-        self.regs.a4 as _
+        self.regs.a4
     }
 
     /// Sets the 4th syscall argument.
@@ -105,7 +105,7 @@ impl TrapFrame {
 
     /// Gets the 5th syscall argument.
     pub const fn arg5(&self) -> usize {
-        self.regs.a5 as _
+        self.regs.a5
     }
 
     /// Sets the 5th syscall argument.
@@ -135,7 +135,7 @@ impl TrapFrame {
 
     /// Gets the return value register.
     pub const fn retval(&self) -> usize {
-        self.regs.a0 as _
+        self.regs.a0
     }
 
     /// Sets the return value register.
@@ -146,6 +146,16 @@ impl TrapFrame {
     /// Sets the return address.
     pub const fn set_ra(&mut self, ra: usize) {
         self.regs.ra = ra;
+    }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> usize {
+        self.regs.tp
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: usize) {
+        self.regs.tp = tls_area;
     }
 }
 
@@ -275,16 +285,6 @@ impl TaskContext {
     pub fn init(&mut self, entry: usize, kstack_top: VirtAddr, tls_area: VirtAddr) {
         self.sp = kstack_top.as_usize();
         self.ra = entry;
-        self.tp = tls_area.as_usize();
-    }
-
-    /// Gets the TLS area.
-    pub fn tls(&self) -> VirtAddr {
-        VirtAddr::from(self.tp)
-    }
-
-    /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tp = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -149,12 +149,12 @@ impl TrapFrame {
     }
 
     /// Gets the TLS area.
-    pub fn tls(&self) -> usize {
+    pub const fn tls(&self) -> usize {
         self.regs.tp
     }
 
     /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls_area: usize) {
+    pub const fn set_tls(&mut self, tls_area: usize) {
         self.regs.tp = tls_area;
     }
 }

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -40,8 +40,8 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     match estat.cause() {
         #[cfg(feature = "uspace")]
         Trap::Exception(Exception::Syscall) => {
-            tf.regs.a0 = crate::trap::handle_syscall(tf, tf.regs.a7) as usize;
             tf.era += 4;
+            tf.regs.a0 = crate::trap::handle_syscall(tf, tf.regs.a7) as usize;
         }
         Trap::Exception(Exception::LoadPageFault)
         | Trap::Exception(Exception::PageNonReadableFault) => {

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -291,7 +291,7 @@ impl core::ops::DerefMut for UspaceContext {
 ///
 /// - Callee-saved registers
 /// - Stack pointer register
-/// - Thread pointer register (for thread-local storage, currently unsupported)
+/// - Thread pointer register (for kernel-space thread-local storage)
 /// - FP/SIMD registers
 ///
 /// On context switch, current task saves its context from CPU to memory,
@@ -317,6 +317,7 @@ pub struct TaskContext {
     pub s10: usize,
     pub s11: usize,
 
+    /// Thread pointer
     pub tp: usize,
     /// The `satp` register value, i.e., the page table root.
     #[cfg(feature = "uspace")]

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -172,12 +172,12 @@ impl TrapFrame {
     }
 
     /// Gets the TLS area.
-    pub fn tls(&self) -> usize {
+    pub const fn tls(&self) -> usize {
         self.regs.tp
     }
 
     /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls_area: usize) {
+    pub const fn set_tls(&mut self, tls_area: usize) {
         self.regs.tp = tls_area;
     }
 }

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -170,6 +170,16 @@ impl TrapFrame {
     pub const fn set_ra(&mut self, ra: usize) {
         self.regs.ra = ra;
     }
+
+    /// Gets the TLS area.
+    pub fn tls(&self) -> usize {
+        self.regs.tp
+    }
+
+    /// Sets the TLS area.
+    pub fn set_tls(&mut self, tls_area: usize) {
+        self.regs.tp = tls_area;
+    }
 }
 
 /// Context to enter user space.
@@ -341,16 +351,6 @@ impl TaskContext {
     pub fn init(&mut self, entry: usize, kstack_top: VirtAddr, tls_area: VirtAddr) {
         self.sp = kstack_top.as_usize();
         self.ra = entry;
-        self.tp = tls_area.as_usize();
-    }
-
-    /// Gets the TLS area.
-    pub fn tls(&self) -> VirtAddr {
-        VirtAddr::from(self.tp)
-    }
-
-    /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls_area: VirtAddr) {
         self.tp = tls_area.as_usize();
     }
 

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -40,8 +40,8 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
         match cause {
             #[cfg(feature = "uspace")]
             Trap::Exception(E::UserEnvCall) => {
-                tf.regs.a0 = crate::trap::handle_syscall(tf, tf.regs.a7) as usize;
                 tf.sepc += 4;
+                tf.regs.a0 = crate::trap::handle_syscall(tf, tf.regs.a7) as usize;
             }
             Trap::Exception(E::LoadPageFault) => {
                 handle_page_fault(tf, MappingFlags::READ, from_user)

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -145,12 +145,12 @@ impl TrapFrame {
     }
 
     /// Gets the TLS area.
-    pub fn tls(&self) -> usize {
+    pub const fn tls(&self) -> usize {
         self.fs_base as _
     }
 
     /// Sets the TLS area.
-    pub fn set_tls(&mut self, tls_area: usize) {
+    pub const fn set_tls(&mut self, tls_area: usize) {
         self.fs_base = tls_area as _;
     }
 }

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -330,7 +330,7 @@ impl fmt::Debug for ExtendedState {
 ///
 /// - Callee-saved registers
 /// - Stack pointer register
-/// - Thread pointer register (for thread-local storage, currently unsupported)
+/// - Thread pointer register (for kernel space thread-local storage)
 /// - FP/SIMD registers
 ///
 /// On context switch, current task saves its context from CPU to memory,
@@ -349,9 +349,11 @@ pub struct TaskContext {
     pub kstack_top: VirtAddr,
     /// `RSP` after all callee-saved registers are pushed.
     pub rsp: u64,
-    /// Thread Local Storage (TLS).
+    /// Thread pointer (FS segment base address)
     pub fs_base: usize,
-    /// The `gs_base` register value.
+    /// User space Thread pointer (GS segment base address)
+    ///
+    /// During task switching, it is written to `KernelGSBase` MSR.
     #[cfg(feature = "uspace")]
     pub gs_base: usize,
     /// Extended states, i.e., FP/SIMD states.

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -1,6 +1,7 @@
 mod context;
 mod gdt;
 mod idt;
+mod tls;
 
 #[cfg(feature = "uspace")]
 mod syscall;

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -1,10 +1,12 @@
 mod context;
 mod gdt;
 mod idt;
-mod tls;
 
 #[cfg(feature = "uspace")]
 mod syscall;
+
+#[cfg(feature = "uspace")]
+mod tls;
 
 #[cfg(target_os = "none")]
 mod trap;

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -8,8 +8,9 @@ syscall_entry:
     sub     rsp, 8                                  // skip user ss
     push    gs:[offset __PERCPU_USER_RSP_OFFSET]    // user rsp
     push    r11                                     // rflags
-    mov     [rsp - 2 * 8], rcx                      // rip
-    sub     rsp, 4 * 8                              // skip until general registers
+    push    {ucode64}                               // cs
+    push    rcx                                     // rip
+    sub     rsp, 2 * 8                              // skip until general registers
 
     push    r15
     push    r14
@@ -26,18 +27,12 @@ syscall_entry:
     push    rdx
     push    rcx
     push    rax
-
     sub     rsp, 16
-    mov     rdi, rsp
-    call    switch_to_kernel_fs_base
 
     mov     rdi, rsp
     call    x86_syscall_handler
 
-    mov     rdi, rsp
-    call    switch_to_user_fs_base
     add     rsp, 16
-
     pop     rax
     pop     rcx
     pop     rdx

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -10,7 +10,7 @@ syscall_entry:
     push    r11                                     // rflags
     push    {ucode64}                               // cs
     push    rcx                                     // rip
-    sub     rsp, 2 * 8                              // skip until general registers
+    sub     rsp, 4 * 8                              // skip until general registers
 
     push    r15
     push    r14
@@ -27,12 +27,10 @@ syscall_entry:
     push    rdx
     push    rcx
     push    rax
-    sub     rsp, 16
 
     mov     rdi, rsp
     call    x86_syscall_handler
 
-    add     rsp, 16
     pop     rax
     pop     rcx
     pop     rdx
@@ -49,7 +47,7 @@ syscall_entry:
     pop     r14
     pop     r15
 
-    add     rsp, 7 * 8
+    add     rsp, 9 * 8
     mov     rcx, [rsp - 5 * 8]  // rip
     mov     r11, [rsp - 3 * 8]  // rflags
     mov     rsp, [rsp - 2 * 8]  // user rsp

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -27,8 +27,16 @@ syscall_entry:
     push    rcx
     push    rax
 
+    sub     rsp, 16
+    mov     rdi, rsp
+    call    switch_to_kernel_fs_base
+
     mov     rdi, rsp
     call    x86_syscall_handler
+
+    mov     rdi, rsp
+    call    switch_to_user_fs_base
+    add     rsp, 16
 
     pop     rax
     pop     rcx

--- a/modules/axhal/src/arch/x86_64/syscall.rs
+++ b/modules/axhal/src/arch/x86_64/syscall.rs
@@ -12,11 +12,18 @@ static USER_RSP_OFFSET: usize = 0;
 core::arch::global_asm!(
     include_str!("syscall.S"),
     tss_rsp0_offset = const core::mem::offset_of!(TaskStateSegment, privilege_stack_table),
+    ucode64 = const GdtStruct::UCODE64_SELECTOR.0,
 );
 
-#[unsafe(no_mangle)]
-pub(super) fn x86_syscall_handler(tf: &mut TrapFrame) {
+pub(super) fn handle_syscall(tf: &mut TrapFrame) {
     tf.rax = crate::trap::handle_syscall(tf, tf.rax as usize) as u64;
+}
+
+#[unsafe(no_mangle)]
+fn x86_syscall_handler(tf: &mut TrapFrame) {
+    super::tls::switch_to_kernel_fs_base(tf);
+    handle_syscall(tf);
+    super::tls::switch_to_user_fs_base(tf);
 }
 
 /// Initializes syscall support and setups the syscall handler.

--- a/modules/axhal/src/arch/x86_64/tls.rs
+++ b/modules/axhal/src/arch/x86_64/tls.rs
@@ -1,36 +1,24 @@
-#[cfg(feature = "uspace")]
-mod uspace {
-    use crate::arch::{TrapFrame, read_thread_pointer, write_thread_pointer};
+use crate::arch::{TrapFrame, read_thread_pointer, write_thread_pointer};
 
-    #[cfg(feature = "tls")]
-    #[unsafe(no_mangle)]
-    #[percpu::def_percpu]
-    static KERNEL_FS_BASE: usize = 0;
+#[cfg(feature = "tls")]
+#[unsafe(no_mangle)]
+#[percpu::def_percpu]
+static KERNEL_FS_BASE: usize = 0;
 
-    #[unsafe(no_mangle)]
-    fn switch_to_kernel_fs_base(tf: &mut TrapFrame) {
+pub fn switch_to_kernel_fs_base(tf: &mut TrapFrame) {
+    if tf.is_user() {
         tf.fs_base = read_thread_pointer() as _;
         #[cfg(feature = "tls")]
         unsafe {
             write_thread_pointer(KERNEL_FS_BASE.read_current())
         };
     }
+}
 
-    #[unsafe(no_mangle)]
-    pub fn switch_to_user_fs_base(tf: &TrapFrame) {
+pub fn switch_to_user_fs_base(tf: &TrapFrame) {
+    if tf.is_user() {
         #[cfg(feature = "tls")]
         KERNEL_FS_BASE.write_current(read_thread_pointer());
         unsafe { write_thread_pointer(tf.fs_base as _) };
     }
 }
-
-#[cfg(feature = "uspace")]
-pub(super) use uspace::switch_to_user_fs_base;
-
-#[cfg(not(feature = "uspace"))]
-#[unsafe(no_mangle)]
-fn switch_to_kernel_fs_base(_tf: &mut super::TrapFrame) {}
-
-#[cfg(not(feature = "uspace"))]
-#[unsafe(no_mangle)]
-pub(super) fn switch_to_user_fs_base(_tf: &super::TrapFrame) {}

--- a/modules/axhal/src/arch/x86_64/tls.rs
+++ b/modules/axhal/src/arch/x86_64/tls.rs
@@ -1,0 +1,36 @@
+#[cfg(feature = "uspace")]
+mod uspace {
+    use crate::arch::{TrapFrame, read_thread_pointer, write_thread_pointer};
+
+    #[cfg(feature = "tls")]
+    #[unsafe(no_mangle)]
+    #[percpu::def_percpu]
+    static KERNEL_FS_BASE: usize = 0;
+
+    #[unsafe(no_mangle)]
+    fn switch_to_kernel_fs_base(tf: &mut TrapFrame) {
+        tf.fs_base = read_thread_pointer() as _;
+        #[cfg(feature = "tls")]
+        unsafe {
+            write_thread_pointer(KERNEL_FS_BASE.read_current())
+        };
+    }
+
+    #[unsafe(no_mangle)]
+    pub fn switch_to_user_fs_base(tf: &TrapFrame) {
+        #[cfg(feature = "tls")]
+        KERNEL_FS_BASE.write_current(read_thread_pointer());
+        unsafe { write_thread_pointer(tf.fs_base as _) };
+    }
+}
+
+#[cfg(feature = "uspace")]
+pub(super) use uspace::switch_to_user_fs_base;
+
+#[cfg(not(feature = "uspace"))]
+#[unsafe(no_mangle)]
+fn switch_to_kernel_fs_base(_tf: &mut super::TrapFrame) {}
+
+#[cfg(not(feature = "uspace"))]
+#[unsafe(no_mangle)]
+pub(super) fn switch_to_user_fs_base(_tf: &super::TrapFrame) {}

--- a/modules/axhal/src/arch/x86_64/trap.S
+++ b/modules/axhal/src/arch/x86_64/trap.S
@@ -47,18 +47,12 @@ _trap_handlers:
     push    rdx
     push    rcx
     push    rax
-
     sub     rsp, 16
-    mov     rdi, rsp
-    call    switch_to_kernel_fs_base
 
     mov     rdi, rsp
     call    x86_trap_handler
 
-    mov     rdi, rsp
-    call    switch_to_user_fs_base
     add     rsp, 16
-
     pop     rax
     pop     rcx
     pop     rdx

--- a/modules/axhal/src/arch/x86_64/trap.S
+++ b/modules/axhal/src/arch/x86_64/trap.S
@@ -32,7 +32,7 @@ _trap_handlers:
     jz      1f
     swapgs
 1:
-    sub     rsp, 16
+    sub     rsp, 16                     # reserve space for fs_base
     push    r15
     push    r14
     push    r13
@@ -68,7 +68,7 @@ _trap_handlers:
     pop     r14
     pop     r15
 
-    add     rsp, 16
+    add     rsp, 16                     # pop fs_base
     test    byte ptr [rsp + 3 * 8], 3   # swap GS back if return to user space
     jz      2f
     swapgs

--- a/modules/axhal/src/arch/x86_64/trap.S
+++ b/modules/axhal/src/arch/x86_64/trap.S
@@ -48,8 +48,16 @@ _trap_handlers:
     push    rcx
     push    rax
 
+    sub     rsp, 16
+    mov     rdi, rsp
+    call    switch_to_kernel_fs_base
+
     mov     rdi, rsp
     call    x86_trap_handler
+
+    mov     rdi, rsp
+    call    switch_to_user_fs_base
+    add     rsp, 16
 
     pop     rax
     pop     rcx

--- a/modules/axhal/src/arch/x86_64/trap.S
+++ b/modules/axhal/src/arch/x86_64/trap.S
@@ -32,6 +32,7 @@ _trap_handlers:
     jz      1f
     swapgs
 1:
+    sub     rsp, 16
     push    r15
     push    r14
     push    r13
@@ -47,12 +48,10 @@ _trap_handlers:
     push    rdx
     push    rcx
     push    rax
-    sub     rsp, 16
 
     mov     rdi, rsp
     call    x86_trap_handler
 
-    add     rsp, 16
     pop     rax
     pop     rcx
     pop     rdx
@@ -69,6 +68,7 @@ _trap_handlers:
     pop     r14
     pop     r15
 
+    add     rsp, 16
     test    byte ptr [rsp + 3 * 8], 3   # swap GS back if return to user space
     jz      2f
     swapgs

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -31,6 +31,7 @@ fn handle_page_fault(tf: &TrapFrame) {
 
 #[unsafe(no_mangle)]
 fn x86_trap_handler(tf: &mut TrapFrame) {
+    super::tls::switch_to_kernel_fs_base(tf);
     match tf.vector as u8 {
         PAGE_FAULT_VECTOR => handle_page_fault(tf),
         BREAKPOINT_VECTOR => debug!("#BP @ {:#x} ", tf.rip),
@@ -41,7 +42,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
         #[cfg(feature = "uspace")]
-        LEGACY_SYSCALL_VECTOR => super::syscall::x86_syscall_handler(tf),
+        LEGACY_SYSCALL_VECTOR => super::syscall::handle_syscall(tf),
         IRQ_VECTOR_START..=IRQ_VECTOR_END => {
             handle_trap!(IRQ, tf.vector as _);
         }
@@ -56,6 +57,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
+    super::tls::switch_to_user_fs_base(tf);
 }
 
 fn vec_to_str(vec: u64) -> &'static str {

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -31,6 +31,7 @@ fn handle_page_fault(tf: &TrapFrame) {
 
 #[unsafe(no_mangle)]
 fn x86_trap_handler(tf: &mut TrapFrame) {
+    #[cfg(feature = "uspace")]
     super::tls::switch_to_kernel_fs_base(tf);
     match tf.vector as u8 {
         PAGE_FAULT_VECTOR => handle_page_fault(tf),
@@ -57,6 +58,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
+    #[cfg(feature = "uspace")]
     super::tls::switch_to_user_fs_base(tf);
 }
 

--- a/modules/axhal/src/trap.rs
+++ b/modules/axhal/src/trap.rs
@@ -20,7 +20,7 @@ pub static PAGE_FAULT: [fn(VirtAddr, MappingFlags, bool) -> bool];
 /// A slice of syscall handler functions.
 #[cfg(feature = "uspace")]
 #[def_trap_handler]
-pub static SYSCALL: [fn(&TrapFrame, usize) -> isize];
+pub static SYSCALL: [fn(&mut TrapFrame, usize) -> isize];
 
 #[allow(unused_macros)]
 macro_rules! handle_trap {
@@ -40,6 +40,6 @@ macro_rules! handle_trap {
 
 /// Call the external syscall handler.
 #[cfg(feature = "uspace")]
-pub(crate) fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
+pub(crate) fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
     SYSCALL[0](tf, syscall_num)
 }

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -519,7 +519,9 @@ impl CurrentTask {
     pub(crate) unsafe fn init_current(init_task: AxTaskRef) {
         assert!(init_task.is_init());
         #[cfg(feature = "tls")]
-        axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
+        unsafe {
+            axhal::arch::write_thread_pointer(init_task.tls.tls_ptr() as usize);
+        }
         let ptr = Arc::into_raw(init_task);
         unsafe {
             axhal::cpu::set_current_task_ptr(ptr);


### PR DESCRIPTION
## Description
This PR fixes two issues in axhal:
1. The instruction pointer should be bumped before calling `handle_syscall` on riscv64 and loongarch64.
2. Isolation between user-level TLS and kernel-level TLS is not considered on aarch64 and x86_64.

Also note that as a result, the `arch_prctl` implementation should write to `TrapFrame` so it's necessary to change `handle_syscall` to accept a `&mut TrapFrame`.

The benefits of this PR:
- The instruction pointer in the `TrapFrame` we get in syscall handlers is unified on all four platforms, that is, it points to the next instruction of the syscall. This again has two benefits:
  - We no longer need to manually bump it when cloning a task (see https://github.com/oscomp/starry-next/blob/0c84473be8a7e3876c62d69f63c2853f404df3a9/api/src/imp/task/clone.rs#L113-L120).
  - Implementing syscall restart is easier: just subtract one syscall instruction length, instead of having to specifically decide on the two platforms that do not increase the instruction pointer after the syscall handler returning.
- User-level TLS is stored in `TrapFrame` and copied when cloning a task. So the [hack](https://github.com/oscomp/starry-next/blob/0c84473be8a7e3876c62d69f63c2853f404df3a9/api/src/imp/task/clone.rs#L113-L120) we used before to copy TLS when cloning tasks by setting kernel-level TLS is no longer needed. What's more, it is now easier to implement `CLONE_SETTLS` by simply calling `set_tls` of `TrapFrame` on all platforms.
- By TLS isolation, we can now use `#[thread_local]` in monolithic kernel just like in unikernel! This allows us to develop with some crates that rely on it, such as [arc_swap](https://docs.rs/arc-swap).

## Related Issues and PRs
- #29 Its `set_tls` is actually a hack, not a real fix.
- #34 It introduces a `try_set_tls`, which is not so good.

## Implementation details
- On aarch64, we use `TPIDRRO_EL0` to temporarily store kernel `TPIDR_EL0`, just like what we do on LoongArch64 to temporarily store `$tp` and `$r21` in some CSRs.
- On x86_64, we use per-cpu storage because I actually don't know a better way to do it. Any suggestions are welcome!