### PR TITLE
feat[axhal]: implement floating point support for loongarch64

### DIFF
--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -43,23 +43,12 @@ pub struct GeneralRegisters {
 /// Floating-point registers of LoongArch64.
 #[cfg(feature = "fp_simd")]
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct FpStatus {
     /// the state of the LoongArch64 Floating-Point Unit (FPU)
     pub fp: [u64; 32],
     pub fcc: usize,  // 条件标志寄存器
-    pub fcsr: usize, // FCSR0寄存器,
-}
-
-#[cfg(feature = "fp_simd")]
-impl Default for FpStatus {
-    fn default() -> Self {
-        Self {
-            fp: [0; 32],
-            fcc: 0,
-            fcsr: 0, // 默认不启用浮点例外,舍入模式为RNE
-        }
-    }
+    pub fcsr: usize, // FCSR0寄存器
 }
 
 /// Saved registers when a trap (interrupt or exception) occurs.
@@ -341,16 +330,8 @@ impl TaskContext {
         #[cfg(feature = "fp_simd")]
         {
             unsafe {
-                save_fp_registers(
-                    &mut self.fp_status.fp,
-                    &mut self.fp_status.fcc,
-                    &mut self.fp_status.fcsr,
-                );
-                restore_fp_registers(
-                    &next_ctx.fp_status.fp,
-                    &next_ctx.fp_status.fcc,
-                    &next_ctx.fp_status.fcsr,
-                );
+                save_fp_registers(&mut self.fp_status);
+                restore_fp_registers(&next_ctx.fp_status);
             }
         }
 
@@ -360,19 +341,11 @@ impl TaskContext {
 
 #[cfg(feature = "fp_simd")]
 #[naked]
-unsafe extern "C" fn save_fp_registers(
-    _fp_registers: &mut [u64; 32],
-    _fcc: &mut usize,
-    _fcsr: &mut usize,
-) {
+unsafe extern "C" fn save_fp_registers(_fp_status: &mut FpStatus) {
     naked_asm!(
-        include_fp_asm_macros!(), // $f24 - $f31
+        include_fp_asm_macros!(),
         "
-        // save old fr context (callee-saved registers)
         PUSH_FLOAT_REGS $a0
-        // save fcc and fcsr
-        SAVE_FCC $a1
-        SAVE_FCSR $a2
         ret
         "
     )
@@ -380,15 +353,11 @@ unsafe extern "C" fn save_fp_registers(
 
 #[cfg(feature = "fp_simd")]
 #[naked]
-unsafe extern "C" fn restore_fp_registers(_fp_registers: &[u64; 32], _fcc: &usize, _fcsr: &usize) {
+unsafe extern "C" fn restore_fp_registers(_fp_status: &FpStatus) {
     naked_asm!(
-        include_fp_asm_macros!(), // $f24 - $f31
+        include_fp_asm_macros!(),
         "
-        // restore new context
         POP_FLOAT_REGS $a0
-        // restore fcc and fcsr
-        RESTORE_FCC $a1
-        RESTORE_FCSR $a2
         ret
         "
     )

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -1,7 +1,7 @@
 use core::arch::naked_asm;
-use memory_addr::VirtAddr;
 #[cfg(feature = "fp_simd")]
 use core::mem::offset_of;
+use memory_addr::VirtAddr;
 
 /// General registers of Loongarch64.
 #[allow(missing_docs)]

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -40,6 +40,28 @@ pub struct GeneralRegisters {
     pub s8: usize,
 }
 
+/// Floating-point registers of LoongArch64.
+#[cfg(feature = "fp_simd")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FpStatus {
+    /// the state of the LoongArch64 Floating-Point Unit (FPU)
+    pub fp: [u64; 32],
+    pub fcc: usize,  // 条件标志寄存器
+    pub fcsr: usize, // FCSR0寄存器,
+}
+
+#[cfg(feature = "fp_simd")]
+impl Default for FpStatus {
+    fn default() -> Self {
+        Self {
+            fp: [0; 32],
+            fcc: 0,
+            fcsr: 0, // 默认不启用浮点例外,舍入模式为RNE
+        }
+    }
+}
+
 /// Saved registers when a trap (interrupt or exception) occurs.
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
@@ -272,6 +294,9 @@ pub struct TaskContext {
     #[cfg(feature = "uspace")]
     /// user page table root
     pub pgdl: usize,
+    #[cfg(feature = "fp_simd")]
+    /// Floating Point Status
+    pub fp_status: FpStatus,
 }
 
 impl TaskContext {
@@ -312,8 +337,61 @@ impl TaskContext {
                 unsafe { super::write_page_table_root0(pa!(next_ctx.pgdl)) };
             }
         }
+
+        #[cfg(feature = "fp_simd")]
+        {
+            unsafe {
+                save_fp_registers(
+                    &mut self.fp_status.fp,
+                    &mut self.fp_status.fcc,
+                    &mut self.fp_status.fcsr,
+                );
+                restore_fp_registers(
+                    &next_ctx.fp_status.fp,
+                    &next_ctx.fp_status.fcc,
+                    &next_ctx.fp_status.fcsr,
+                );
+            }
+        }
+
         unsafe { context_switch(self, next_ctx) }
     }
+}
+
+#[cfg(feature = "fp_simd")]
+#[naked]
+unsafe extern "C" fn save_fp_registers(
+    _fp_registers: &mut [u64; 32],
+    _fcc: &mut usize,
+    _fcsr: &mut usize,
+) {
+    naked_asm!(
+        include_fp_asm_macros!(), // $f24 - $f31
+        "
+        // save old fr context (callee-saved registers)
+        PUSH_FLOAT_REGS $a0
+        // save fcc and fcsr
+        SAVE_FCC $a1
+        SAVE_FCSR $a2
+        ret
+        "
+    )
+}
+
+#[cfg(feature = "fp_simd")]
+#[naked]
+unsafe extern "C" fn restore_fp_registers(_fp_registers: &[u64; 32], _fcc: &usize, _fcsr: &usize) {
+    naked_asm!(
+        include_fp_asm_macros!(), // $f24 - $f31
+        "
+        // restore new context
+        POP_FLOAT_REGS $a0
+        // restore fcc and fcsr
+        RESTORE_FCC $a1
+        RESTORE_FCSR $a2
+        ret
+        "
+    )
 }
 
 #[naked]

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -346,6 +346,10 @@ unsafe extern "C" fn save_fp_registers(_fp_status: &mut FpStatus) {
         include_fp_asm_macros!(),
         "
         PUSH_FLOAT_REGS $a0
+        addi.d  $t8, $a0, 256
+        SAVE_FCC $t8
+        addi.d  $t8, $a0, 264
+        SAVE_FCSR $t8
         ret
         "
     )
@@ -358,6 +362,10 @@ unsafe extern "C" fn restore_fp_registers(_fp_status: &FpStatus) {
         include_fp_asm_macros!(),
         "
         POP_FLOAT_REGS $a0
+        addi.d  $t8, $a0, 256
+        RESTORE_FCC $t8
+        addi.d  $t8, $a0, 264
+        RESTORE_FCSR $t8
         ret
         "
     )

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -81,17 +81,10 @@ macro_rules! include_asm_macros {
 macro_rules! include_fp_asm_macros {
     () => {
         concat!(
-            include_asm_macros!(), // Changed from __asm_macros!
+            include_asm_macros!(),
             r#"
             .ifndef FP_MACROS_FLAG
             .equ FP_MACROS_FLAG, 1
-
-            .macro FSTD fr, base_reg, off
-                fst.d   \fr, \base_reg, \off*8
-            .endm
-            .macro FLDD fr, base_reg, off
-                fld.d   \fr, \base_reg, \off*8
-            .endm
 
             .macro SAVE_FCSR, base
                 movfcsr2gr $t0, $fcsr0
@@ -178,10 +171,18 @@ macro_rules! include_fp_asm_macros {
 
             .macro PUSH_FLOAT_REGS, base_reg
                 PUSH_POP_FLOAT_REGS fst.d, \base_reg
+                addi.d  $t8, \base_reg, 256
+                SAVE_FCC $t8
+                addi.d  $t8, \base_reg, 264
+                SAVE_FCSR $t8
             .endm
 
             .macro POP_FLOAT_REGS, base_reg
                 PUSH_POP_FLOAT_REGS fld.d, \base_reg
+                addi.d  $t8, \base_reg, 256
+                RESTORE_FCC $t8
+                addi.d  $t8, \base_reg, 264
+                RESTORE_FCSR $t8
             .endm
 
             .endif"#

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -105,33 +105,33 @@ macro_rules! include_fp_asm_macros {
         .endm
 
         .macro RESTORE_FCC, base
-            ld.d	    $t0, \base, 0
-            bstrpick.d	$t1, $t0, 7, 0
-            movgr2cf	$fcc0, $t1
-            bstrpick.d	$t1, $t0, 15, 8
-            movgr2cf	$fcc1, $t1
-            bstrpick.d	$t1, $t0, 23, 16
-            movgr2cf	$fcc2, $t1
-            bstrpick.d	$t1, $t0, 31, 24
-            movgr2cf	$fcc3, $t1
-            bstrpick.d	$t1, $t0, 39, 32
-            movgr2cf	$fcc4, $t1
-            bstrpick.d	$t1, $t0, 47, 40
-            movgr2cf	$fcc5, $t1
-            bstrpick.d	$t1, $t0, 55, 48
-            movgr2cf	$fcc6, $t1
-            bstrpick.d	$t1, $t0, 63, 56
-            movgr2cf	$fcc7, $t1
+            ld.d        $t0, \base, 0
+            bstrpick.d  $t1, $t0, 7, 0
+            movgr2cf    $fcc0, $t1
+            bstrpick.d  $t1, $t0, 15, 8
+            movgr2cf    $fcc1, $t1
+            bstrpick.d  $t1, $t0, 23, 16
+            movgr2cf    $fcc2, $t1
+            bstrpick.d  $t1, $t0, 31, 24
+            movgr2cf    $fcc3, $t1
+            bstrpick.d  $t1, $t0, 39, 32
+            movgr2cf    $fcc4, $t1
+            bstrpick.d  $t1, $t0, 47, 40
+            movgr2cf    $fcc5, $t1
+            bstrpick.d  $t1, $t0, 55, 48
+            movgr2cf    $fcc6, $t1
+            bstrpick.d  $t1, $t0, 63, 56
+            movgr2cf    $fcc7, $t1
         .endm
 
         .macro SAVE_FCSR, base
-            movfcsr2gr	$t0, $fcsr0
+            movfcsr2gr  $t0, $fcsr0
             st.w        $t0, \base, 0
         .endm
 
         .macro RESTORE_FCSR, base
             ld.w        $t0, \base, 0
-            movgr2fcsr	$fcsr0, $t0
+            movgr2fcsr  $fcsr0, $t0
         .endm
 
         // LoongArch64 specific floating point macros

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -76,3 +76,115 @@ macro_rules! include_asm_macros {
         .endif"
     };
 }
+
+#[cfg(feature = "fp_simd")]
+macro_rules! include_fp_asm_macros {
+    () => {
+        concat!(
+            include_asm_macros!(), // Changed from __asm_macros!
+            r#"
+            .ifndef FP_MACROS_FLAG
+            .equ FP_MACROS_FLAG, 1
+
+            .macro FSTD fr, base_reg, off
+                fst.d   \fr, \base_reg, \off*8
+            .endm
+            .macro FLDD fr, base_reg, off
+                fld.d   \fr, \base_reg, \off*8
+            .endm
+
+            .macro SAVE_FCSR, base
+                movfcsr2gr $t0, $fcsr0
+                st.d $t0, \base, 0*8
+            .endm
+            .macro SAVE_FCC, base
+                movcf2gr $t0, $fcc0
+                movcf2gr $t1, $fcc1
+                movcf2gr $t2, $fcc2
+                movcf2gr $t3, $fcc3
+                movcf2gr $t4, $fcc4
+                movcf2gr $t5, $fcc5
+                movcf2gr $t6, $fcc6
+                movcf2gr $t7, $fcc7
+                st.d $t0, \base, 0
+                st.d $t1, \base, 1
+                st.d $t2, \base, 2
+                st.d $t3, \base, 3
+                st.d $t4, \base, 4
+                st.d $t5, \base, 5
+                st.d $t6, \base, 6
+                st.d $t7, \base, 7
+            .endm
+
+            .macro RESTORE_FCSR, base
+                movgr2fcsr $fcsr0, $t0
+                ld.d $t0, \base, 0*8
+            .endm
+            .macro RESTORE_FCC, base
+                ld.d $t0, \base, 0
+                ld.d $t1, \base, 1
+                ld.d $t2, \base, 2
+                ld.d $t3, \base, 3
+                ld.d $t4, \base, 4
+                ld.d $t5, \base, 5
+                ld.d $t6, \base, 6
+                ld.d $t7, \base, 7
+                movgr2cf $fcc0, $t0
+                movgr2cf $fcc1, $t1
+                movgr2cf $fcc2, $t2
+                movgr2cf $fcc3, $t3
+                movgr2cf $fcc4, $t4
+                movgr2cf $fcc5, $t5
+                movgr2cf $fcc6, $t6
+                movgr2cf $fcc7, $t7
+            .endm
+
+
+            // LoongArch64 specific floating point macros
+            .macro PUSH_POP_FLOAT_REGS, op, base_reg
+                \op $f0,  \base_reg, 0*8
+                \op $f1,  \base_reg, 1*8
+                \op $f2,  \base_reg, 2*8
+                \op $f3,  \base_reg, 3*8
+                \op $f4,  \base_reg, 4*8
+                \op $f5,  \base_reg, 5*8
+                \op $f6,  \base_reg, 6*8
+                \op $f7,  \base_reg, 7*8
+                \op $f8,  \base_reg, 8*8
+                \op $f9,  \base_reg, 9*8
+                \op $f10, \base_reg, 10*8
+                \op $f11, \base_reg, 11*8
+                \op $f12, \base_reg, 12*8
+                \op $f13, \base_reg, 13*8
+                \op $f14, \base_reg, 14*8
+                \op $f15, \base_reg, 15*8
+                \op $f16, \base_reg, 16*8
+                \op $f17, \base_reg, 17*8
+                \op $f18, \base_reg, 18*8
+                \op $f19, \base_reg, 19*8
+                \op $f20, \base_reg, 20*8
+                \op $f21, \base_reg, 21*8
+                \op $f22, \base_reg, 22*8
+                \op $f23, \base_reg, 23*8
+                \op $f24, \base_reg, 24*8
+                \op $f25, \base_reg, 25*8
+                \op $f26, \base_reg, 26*8
+                \op $f27, \base_reg, 27*8
+                \op $f28, \base_reg, 28*8
+                \op $f29, \base_reg, 29*8
+                \op $f30, \base_reg, 30*8
+                \op $f31, \base_reg, 31*8
+            .endm
+
+            .macro PUSH_FLOAT_REGS, base_reg
+                PUSH_POP_FLOAT_REGS fst.d, \base_reg
+            .endm
+
+            .macro POP_FLOAT_REGS, base_reg
+                PUSH_POP_FLOAT_REGS fld.d, \base_reg
+            .endm
+
+            .endif"#
+        )
+    };
+}

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -84,52 +84,55 @@ macro_rules! include_fp_asm_macros {
         .ifndef FP_MACROS_FLAG
         .equ FP_MACROS_FLAG, 1
 
-        .macro SAVE_FCSR, base
-            movfcsr2gr $t0, $fcsr0
-            st.d $t0, \base, 0*8
-        .endm
         .macro SAVE_FCC, base
-            movcf2gr $t0, $fcc0
-            movcf2gr $t1, $fcc1
-            movcf2gr $t2, $fcc2
-            movcf2gr $t3, $fcc3
-            movcf2gr $t4, $fcc4
-            movcf2gr $t5, $fcc5
-            movcf2gr $t6, $fcc6
-            movcf2gr $t7, $fcc7
-            st.d $t0, \base, 0
-            st.d $t1, \base, 1
-            st.d $t2, \base, 2
-            st.d $t3, \base, 3
-            st.d $t4, \base, 4
-            st.d $t5, \base, 5
-            st.d $t6, \base, 6
-            st.d $t7, \base, 7
+            movcf2gr    $t0, $fcc0
+            move        $t1, $t0
+            movcf2gr    $t0, $fcc1
+            bstrins.d   $t1, $t0, 15, 8
+            movcf2gr    $t0, $fcc2
+            bstrins.d   $t1, $t0, 23, 16
+            movcf2gr    $t0, $fcc3
+            bstrins.d   $t1, $t0, 31, 24
+            movcf2gr    $t0, $fcc4
+            bstrins.d   $t1, $t0, 39, 32
+            movcf2gr    $t0, $fcc5
+            bstrins.d   $t1, $t0, 47, 40
+            movcf2gr    $t0, $fcc6
+            bstrins.d   $t1, $t0, 55, 48
+            movcf2gr    $t0, $fcc7
+            bstrins.d   $t1, $t0, 63, 56
+            st.d        $t1, \base, 0
+        .endm
+
+        .macro RESTORE_FCC, base
+            ld.d	    $t0, \base, 0
+            bstrpick.d	$t1, $t0, 7, 0
+            movgr2cf	$fcc0, $t1
+            bstrpick.d	$t1, $t0, 15, 8
+            movgr2cf	$fcc1, $t1
+            bstrpick.d	$t1, $t0, 23, 16
+            movgr2cf	$fcc2, $t1
+            bstrpick.d	$t1, $t0, 31, 24
+            movgr2cf	$fcc3, $t1
+            bstrpick.d	$t1, $t0, 39, 32
+            movgr2cf	$fcc4, $t1
+            bstrpick.d	$t1, $t0, 47, 40
+            movgr2cf	$fcc5, $t1
+            bstrpick.d	$t1, $t0, 55, 48
+            movgr2cf	$fcc6, $t1
+            bstrpick.d	$t1, $t0, 63, 56
+            movgr2cf	$fcc7, $t1
+        .endm
+
+        .macro SAVE_FCSR, base
+            movfcsr2gr	$t0, $fcsr0
+            st.w        $t0, \base, 0
         .endm
 
         .macro RESTORE_FCSR, base
-            movgr2fcsr $fcsr0, $t0
-            ld.d $t0, \base, 0*8
+            ld.w        $t0, \base, 0
+            movgr2fcsr	$fcsr0, $t0
         .endm
-        .macro RESTORE_FCC, base
-            ld.d $t0, \base, 0
-            ld.d $t1, \base, 1
-            ld.d $t2, \base, 2
-            ld.d $t3, \base, 3
-            ld.d $t4, \base, 4
-            ld.d $t5, \base, 5
-            ld.d $t6, \base, 6
-            ld.d $t7, \base, 7
-            movgr2cf $fcc0, $t0
-            movgr2cf $fcc1, $t1
-            movgr2cf $fcc2, $t2
-            movgr2cf $fcc3, $t3
-            movgr2cf $fcc4, $t4
-            movgr2cf $fcc5, $t5
-            movgr2cf $fcc6, $t6
-            movgr2cf $fcc7, $t7
-        .endm
-
 
         // LoongArch64 specific floating point macros
         .macro PUSH_POP_FLOAT_REGS, op, base_reg

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -80,112 +80,101 @@ macro_rules! include_asm_macros {
 #[cfg(feature = "fp_simd")]
 macro_rules! include_fp_asm_macros {
     () => {
-        concat!(
-            include_asm_macros!(),
-            r#"
-            .ifndef FP_MACROS_FLAG
-            .equ FP_MACROS_FLAG, 1
+        r#"
+        .ifndef FP_MACROS_FLAG
+        .equ FP_MACROS_FLAG, 1
 
-            .macro SAVE_FCSR, base
-                movfcsr2gr $t0, $fcsr0
-                st.d $t0, \base, 0*8
-            .endm
-            .macro SAVE_FCC, base
-                movcf2gr $t0, $fcc0
-                movcf2gr $t1, $fcc1
-                movcf2gr $t2, $fcc2
-                movcf2gr $t3, $fcc3
-                movcf2gr $t4, $fcc4
-                movcf2gr $t5, $fcc5
-                movcf2gr $t6, $fcc6
-                movcf2gr $t7, $fcc7
-                st.d $t0, \base, 0
-                st.d $t1, \base, 1
-                st.d $t2, \base, 2
-                st.d $t3, \base, 3
-                st.d $t4, \base, 4
-                st.d $t5, \base, 5
-                st.d $t6, \base, 6
-                st.d $t7, \base, 7
-            .endm
+        .macro SAVE_FCSR, base
+            movfcsr2gr $t0, $fcsr0
+            st.d $t0, \base, 0*8
+        .endm
+        .macro SAVE_FCC, base
+            movcf2gr $t0, $fcc0
+            movcf2gr $t1, $fcc1
+            movcf2gr $t2, $fcc2
+            movcf2gr $t3, $fcc3
+            movcf2gr $t4, $fcc4
+            movcf2gr $t5, $fcc5
+            movcf2gr $t6, $fcc6
+            movcf2gr $t7, $fcc7
+            st.d $t0, \base, 0
+            st.d $t1, \base, 1
+            st.d $t2, \base, 2
+            st.d $t3, \base, 3
+            st.d $t4, \base, 4
+            st.d $t5, \base, 5
+            st.d $t6, \base, 6
+            st.d $t7, \base, 7
+        .endm
 
-            .macro RESTORE_FCSR, base
-                movgr2fcsr $fcsr0, $t0
-                ld.d $t0, \base, 0*8
-            .endm
-            .macro RESTORE_FCC, base
-                ld.d $t0, \base, 0
-                ld.d $t1, \base, 1
-                ld.d $t2, \base, 2
-                ld.d $t3, \base, 3
-                ld.d $t4, \base, 4
-                ld.d $t5, \base, 5
-                ld.d $t6, \base, 6
-                ld.d $t7, \base, 7
-                movgr2cf $fcc0, $t0
-                movgr2cf $fcc1, $t1
-                movgr2cf $fcc2, $t2
-                movgr2cf $fcc3, $t3
-                movgr2cf $fcc4, $t4
-                movgr2cf $fcc5, $t5
-                movgr2cf $fcc6, $t6
-                movgr2cf $fcc7, $t7
-            .endm
+        .macro RESTORE_FCSR, base
+            movgr2fcsr $fcsr0, $t0
+            ld.d $t0, \base, 0*8
+        .endm
+        .macro RESTORE_FCC, base
+            ld.d $t0, \base, 0
+            ld.d $t1, \base, 1
+            ld.d $t2, \base, 2
+            ld.d $t3, \base, 3
+            ld.d $t4, \base, 4
+            ld.d $t5, \base, 5
+            ld.d $t6, \base, 6
+            ld.d $t7, \base, 7
+            movgr2cf $fcc0, $t0
+            movgr2cf $fcc1, $t1
+            movgr2cf $fcc2, $t2
+            movgr2cf $fcc3, $t3
+            movgr2cf $fcc4, $t4
+            movgr2cf $fcc5, $t5
+            movgr2cf $fcc6, $t6
+            movgr2cf $fcc7, $t7
+        .endm
 
 
-            // LoongArch64 specific floating point macros
-            .macro PUSH_POP_FLOAT_REGS, op, base_reg
-                \op $f0,  \base_reg, 0*8
-                \op $f1,  \base_reg, 1*8
-                \op $f2,  \base_reg, 2*8
-                \op $f3,  \base_reg, 3*8
-                \op $f4,  \base_reg, 4*8
-                \op $f5,  \base_reg, 5*8
-                \op $f6,  \base_reg, 6*8
-                \op $f7,  \base_reg, 7*8
-                \op $f8,  \base_reg, 8*8
-                \op $f9,  \base_reg, 9*8
-                \op $f10, \base_reg, 10*8
-                \op $f11, \base_reg, 11*8
-                \op $f12, \base_reg, 12*8
-                \op $f13, \base_reg, 13*8
-                \op $f14, \base_reg, 14*8
-                \op $f15, \base_reg, 15*8
-                \op $f16, \base_reg, 16*8
-                \op $f17, \base_reg, 17*8
-                \op $f18, \base_reg, 18*8
-                \op $f19, \base_reg, 19*8
-                \op $f20, \base_reg, 20*8
-                \op $f21, \base_reg, 21*8
-                \op $f22, \base_reg, 22*8
-                \op $f23, \base_reg, 23*8
-                \op $f24, \base_reg, 24*8
-                \op $f25, \base_reg, 25*8
-                \op $f26, \base_reg, 26*8
-                \op $f27, \base_reg, 27*8
-                \op $f28, \base_reg, 28*8
-                \op $f29, \base_reg, 29*8
-                \op $f30, \base_reg, 30*8
-                \op $f31, \base_reg, 31*8
-            .endm
+        // LoongArch64 specific floating point macros
+        .macro PUSH_POP_FLOAT_REGS, op, base_reg
+            \op $f0,  \base_reg, 0*8
+            \op $f1,  \base_reg, 1*8
+            \op $f2,  \base_reg, 2*8
+            \op $f3,  \base_reg, 3*8
+            \op $f4,  \base_reg, 4*8
+            \op $f5,  \base_reg, 5*8
+            \op $f6,  \base_reg, 6*8
+            \op $f7,  \base_reg, 7*8
+            \op $f8,  \base_reg, 8*8
+            \op $f9,  \base_reg, 9*8
+            \op $f10, \base_reg, 10*8
+            \op $f11, \base_reg, 11*8
+            \op $f12, \base_reg, 12*8
+            \op $f13, \base_reg, 13*8
+            \op $f14, \base_reg, 14*8
+            \op $f15, \base_reg, 15*8
+            \op $f16, \base_reg, 16*8
+            \op $f17, \base_reg, 17*8
+            \op $f18, \base_reg, 18*8
+            \op $f19, \base_reg, 19*8
+            \op $f20, \base_reg, 20*8
+            \op $f21, \base_reg, 21*8
+            \op $f22, \base_reg, 22*8
+            \op $f23, \base_reg, 23*8
+            \op $f24, \base_reg, 24*8
+            \op $f25, \base_reg, 25*8
+            \op $f26, \base_reg, 26*8
+            \op $f27, \base_reg, 27*8
+            \op $f28, \base_reg, 28*8
+            \op $f29, \base_reg, 29*8
+            \op $f30, \base_reg, 30*8
+            \op $f31, \base_reg, 31*8
+        .endm
 
-            .macro PUSH_FLOAT_REGS, base_reg
-                PUSH_POP_FLOAT_REGS fst.d, \base_reg
-                addi.d  $t8, \base_reg, 256
-                SAVE_FCC $t8
-                addi.d  $t8, \base_reg, 264
-                SAVE_FCSR $t8
-            .endm
+        .macro PUSH_FLOAT_REGS, base_reg
+            PUSH_POP_FLOAT_REGS fst.d, \base_reg
+        .endm
 
-            .macro POP_FLOAT_REGS, base_reg
-                PUSH_POP_FLOAT_REGS fld.d, \base_reg
-                addi.d  $t8, \base_reg, 256
-                RESTORE_FCC $t8
-                addi.d  $t8, \base_reg, 264
-                RESTORE_FCSR $t8
-            .endm
+        .macro POP_FLOAT_REGS, base_reg
+            PUSH_POP_FLOAT_REGS fld.d, \base_reg
+        .endm
 
-            .endif"#
-        )
+        .endif"#
     };
 }


### PR DESCRIPTION
## Description  
Implement floating point support for loongarch

## Related Issues(If necessary)
https://github.com/oscomp/arceos/issues/26

## Implementation Details  
Save and restore fp registers on context switch.

## How to Test  
use starry-next to test
```c
// libc/c/float

#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <stdint.h>   // 用于 uintptr_t
#include <math.h>     // 用于 fabs
#include <unistd.h>   // 对于 fork, _exit, usleep/sched_yield
#include <sys/wait.h> // 对于 waitpid

#define NUM_FP_REGS 32
#define FP_VAL_EQUAL_THRESHOLD 1e-12
#define NUM_CHILD_PROCESSES 2 // 创建多少个子进程进行测试
#define YIELD_ITERATIONS 5    // 每个子进程尝试让出CPU的次数

// 为每个子进程准备的不同的初始浮点值
double child_initial_values[NUM_CHILD_PROCESSES][NUM_FP_REGS];
// 每个子进程从浮点寄存器恢复后读回的值 (在子进程的栈上分配)

// 初始化所有子进程的测试数据
void initialize_fp_values_for_children()
{
    for (int child_idx = 0; child_idx < NUM_CHILD_PROCESSES; ++child_idx)
    {
        for (int i = 0; i < NUM_FP_REGS; ++i)
        {
            // 确保每个子进程的值集是独特的
            child_initial_values[child_idx][i] = (double)i + 0.12345 + ((double)child_idx * 0.01);
        }
    }
}

// 子进程执行的函数
// child_id: 子进程的逻辑ID (0 to NUM_CHILD_PROCESSES-1)
// returns: 0 on success, 1 on failure
int child_process_task(int child_id)
{
    double restored_values_from_regs[NUM_FP_REGS]; // 子进程本地的恢复值存储区

    printf("[Child %d, PID %d] 开始执行。\n", child_id, getpid());

    uintptr_t p_my_initial_values = (uintptr_t)child_initial_values[child_id];
    uintptr_t p_my_restored_values = (uintptr_t)restored_values_from_regs;

    // 步骤 1: 将该子进程特定的 initial_values 加载到浮点寄存器 $f0-$f31
    asm volatile(
        "fld.d $f0,  %[initial_addr], 0\n\t"
        "fld.d $f1,  %[initial_addr], 8\n\t"
        "fld.d $f2,  %[initial_addr], 16\n\t"
        "fld.d $f3,  %[initial_addr], 24\n\t"
        "fld.d $f4,  %[initial_addr], 32\n\t"
        "fld.d $f5,  %[initial_addr], 40\n\t"
        "fld.d $f6,  %[initial_addr], 48\n\t"
        "fld.d $f7,  %[initial_addr], 56\n\t"
        "fld.d $f8,  %[initial_addr], 64\n\t"
        "fld.d $f9,  %[initial_addr], 72\n\t"
        "fld.d $f10, %[initial_addr], 80\n\t"
        "fld.d $f11, %[initial_addr], 88\n\t"
        "fld.d $f12, %[initial_addr], 96\n\t"
        "fld.d $f13, %[initial_addr], 104\n\t"
        "fld.d $f14, %[initial_addr], 112\n\t"
        "fld.d $f15, %[initial_addr], 120\n\t"
        "fld.d $f16, %[initial_addr], 128\n\t"
        "fld.d $f17, %[initial_addr], 136\n\t"
        "fld.d $f18, %[initial_addr], 144\n\t"
        "fld.d $f19, %[initial_addr], 152\n\t"
        "fld.d $f20, %[initial_addr], 160\n\t"
        "fld.d $f21, %[initial_addr], 168\n\t"
        "fld.d $f22, %[initial_addr], 176\n\t"
        "fld.d $f23, %[initial_addr], 184\n\t"
        "fld.d $f24, %[initial_addr], 192\n\t"
        "fld.d $f25, %[initial_addr], 200\n\t"
        "fld.d $f26, %[initial_addr], 208\n\t"
        "fld.d $f27, %[initial_addr], 216\n\t"
        "fld.d $f28, %[initial_addr], 224\n\t"
        "fld.d $f29, %[initial_addr], 232\n\t"
        "fld.d $f30, %[initial_addr], 240\n\t"
        "fld.d $f31, %[initial_addr], 248\n\t"
        : // no outputs
        : [initial_addr] "r"(p_my_initial_values)
        : "memory", "$f0", "$f1", "$f2", "$f3", "$f4", "$f5", "$f6", "$f7",
          "$f8", "$f9", "$f10", "$f11", "$f12", "$f13", "$f14", "$f15",
          "$f16", "$f17", "$f18", "$f19", "$f20", "$f21", "$f22", "$f23",
          "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30", "$f31");

    printf("[Child %d, PID %d] 已加载其独特的FP值到寄存器。\n", child_id, getpid());

    // 步骤 2: 尝试让出CPU，鼓励上下文切换
    for (int i = 0; i < YIELD_ITERATIONS; ++i)
    {
#ifdef _POSIX_PRIORITY_SCHEDULING
        sched_yield(); // POSIX 标准的让出方式
#else
        usleep(1000); // 备选：休眠1毫秒，如果 sched_yield 不可用或效果不佳
#endif
    }

    printf("[Child %d, PID %d] 已完成让出CPU尝试，现在从寄存器读回FP值。\n", child_id, getpid());

    // 步骤 3: 将当前浮点寄存器 $f0-$f31 的内容存储到 restored_values_from_regs
    asm volatile(
        "fst.d $f0,  %[restored_addr], 0\n\t"
        "fst.d $f1,  %[restored_addr], 8\n\t"
        "fst.d $f2,  %[restored_addr], 16\n\t"
        "fst.d $f3,  %[restored_addr], 24\n\t"
        "fst.d $f4,  %[restored_addr], 32\n\t"
        "fst.d $f5,  %[restored_addr], 40\n\t"
        "fst.d $f6,  %[restored_addr], 48\n\t"
        "fst.d $f7,  %[restored_addr], 56\n\t"
        "fst.d $f8,  %[restored_addr], 64\n\t"
        "fst.d $f9,  %[restored_addr], 72\n\t"
        "fst.d $f10, %[restored_addr], 80\n\t"
        "fst.d $f11, %[restored_addr], 88\n\t"
        "fst.d $f12, %[restored_addr], 96\n\t"
        "fst.d $f13, %[restored_addr], 104\n\t"
        "fst.d $f14, %[restored_addr], 112\n\t"
        "fst.d $f15, %[restored_addr], 120\n\t"
        "fst.d $f16, %[restored_addr], 128\n\t"
        "fst.d $f17, %[restored_addr], 136\n\t"
        "fst.d $f18, %[restored_addr], 144\n\t"
        "fst.d $f19, %[restored_addr], 152\n\t"
        "fst.d $f20, %[restored_addr], 160\n\t"
        "fst.d $f21, %[restored_addr], 168\n\t"
        "fst.d $f22, %[restored_addr], 176\n\t"
        "fst.d $f23, %[restored_addr], 184\n\t"
        "fst.d $f24, %[restored_addr], 192\n\t"
        "fst.d $f25, %[restored_addr], 200\n\t"
        "fst.d $f26, %[restored_addr], 208\n\t"
        "fst.d $f27, %[restored_addr], 216\n\t"
        "fst.d $f28, %[restored_addr], 224\n\t"
        "fst.d $f29, %[restored_addr], 232\n\t"
        "fst.d $f30, %[restored_addr], 240\n\t"
        "fst.d $f31, %[restored_addr], 248\n\t"
        : // no outputs
        : [restored_addr] "r"(p_my_restored_values)
        : "memory", "$f0", "$f1", "$f2", "$f3", "$f4", "$f5", "$f6", "$f7",
          "$f8", "$f9", "$f10", "$f11", "$f12", "$f13", "$f14", "$f15",
          "$f16", "$f17", "$f18", "$f19", "$f20", "$f21", "$f22", "$f23",
          "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30", "$f31" // Clobber list might not be strictly needed here if no other C code uses FP regs before comparison
    );

    // 步骤 4: 比较 initial_values 和 restored_values_from_regs
    int mismatches = 0;
    for (int i = 0; i < NUM_FP_REGS; ++i)
    {
        if (fabs(child_initial_values[child_id][i] - restored_values_from_regs[i]) > FP_VAL_EQUAL_THRESHOLD)
        {
            printf("[Child %d, PID %d] 错误：$f%02d 寄存器值不匹配：期望值=%.17g, 恢复值=%.17g, 差值=%.17g\n",
                   child_id, getpid(), i, child_initial_values[child_id][i], restored_values_from_regs[i],
                   fabs(child_initial_values[child_id][i] - restored_values_from_regs[i]));
            mismatches++;
        }
    }

    if (mismatches == 0)
    {
        printf("[Child %d, PID %d] 成功：所有 %d 个浮点寄存器在上下文切换后值正确。\n", child_id, getpid(), NUM_FP_REGS);
        return 0; // Success
    }
    else
    {
        printf("[Child %d, PID %d] 失败：%d 个浮点寄存器在上下文切换后值不匹配。\n", child_id, getpid(), mismatches);
        return 1; // Failure
    }
}

int main()
{
    printf("主进程开始：测试LoongArch64浮点上下文切换保存。\n");
    printf("将创建 %d 个子进程。\n", NUM_CHILD_PROCESSES);

    initialize_fp_values_for_children();
    printf("为子进程初始化浮点值完毕。\n");

    pid_t pids[NUM_CHILD_PROCESSES];
    int overall_failures = 0;

    for (int i = 0; i < NUM_CHILD_PROCESSES; ++i)
    {
        pids[i] = fork();
        if (pids[i] < 0)
        {
            perror("fork 失败");
            // 清理已创建的子进程（如果需要更复杂的错误处理）
            for (int k = 0; k < i; ++k)
            {
                kill(pids[k], SIGKILL); // 简单粗暴地终止
                waitpid(pids[k], NULL, 0);
            }
            return EXIT_FAILURE;
        }
        else if (pids[i] == 0)
        {
            // 子进程
            int child_status = child_process_task(i);
            _exit(child_status); // 使用 _exit 避免刷新父进程的 stdio 缓冲区
        }
        // 父进程继续循环创建下一个子进程
        printf("主进程：已创建子进程 %d (PID %d)。\n", i, pids[i]);
    }

    printf("主进程：所有子进程已创建，等待它们完成...\n");

    for (int i = 0; i < NUM_CHILD_PROCESSES; ++i)
    {
        int status;
        pid_t child_pid = waitpid(pids[i], &status, 0);

        if (child_pid > 0)
        {
            if (WIFEXITED(status))
            {
                int exit_status = WEXITSTATUS(status);
                printf("主进程：子进程 %d (PID %d) 已退出，状态码 %d。\n", i, child_pid, exit_status);
                if (exit_status != 0)
                {
                    overall_failures++;
                }
            }
            else if (WIFSIGNALED(status))
            {
                printf("主进程：子进程 %d (PID %d) 被信号 %d 终止。\n", i, child_pid, WTERMSIG(status));
                overall_failures++;
            }
            else
            {
                printf("主进程：子进程 %d (PID %d) 以未知状态结束。\n", i, child_pid);
                overall_failures++;
            }
        }
        else
        {
            perror("waitpid 失败");
            overall_failures++; // 认为等待失败也是一种测试失败
        }
    }

    printf("\n--- 测试总结 ---\n");
    if (overall_failures == 0)
    {
        printf("成功：所有 %d 个子进程都验证了浮点上下文在其执行期间被正确保存和恢复。\n", NUM_CHILD_PROCESSES);
        return EXIT_SUCCESS;
    }
    else
    {
        printf("失败：%d 个子进程报告了浮点上下文保存/恢复问题，或在执行中遇到错误。\n", overall_failures);
        return EXIT_FAILURE;
    }
}
```
### usage
```bash
make ARCH=loongarch64 AX_TESTCASE=libc user_apps
make ARCH=loongarch64 defconfig
make ARCH=loongarch64 AX_TESTCASE=libc BLK=y NET=y ACCEL=n FEATURES=fp_simd run
```

### before
![image](https://github.com/user-attachments/assets/0610363c-7734-4df0-b3f4-05997839f493)
### after
![image](https://github.com/user-attachments/assets/829c1cf3-052c-4635-9edd-d970bf79b612)

## Additional Notes  
Test cases are only valid for loongarch.
