### PR TITLE
Revert "fix:Frequent context switch leads to IRQ being silenced (#42)"

### DIFF
--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -107,9 +107,6 @@ fn handle_data_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
 fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
     let esr = ESR_EL1.extract();
     let iss = esr.read(ESR_EL1::ISS);
-
-    unmask_interrupts_for_exception(tf);
-
     match esr.read_as_enum(ESR_EL1::EC) {
         #[cfg(feature = "uspace")]
         Some(ESR_EL1::EC::Value::SVC64) => {
@@ -134,22 +131,4 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
         }
     }
     crate::trap::post_trap_callback(tf, source.is_from_user());
-}
-
-// Interrupt unmasking function for exception handling.
-// NOTE: It must be invoked after the switch to kernel mode has finished
-//
-// If interrupts were enabled before the exception (`I` bit in `SPSR` is unmask),
-// re-enable interrupts before handling the exception.
-//
-// On aarch64, when an exception occurs, the `CPSR` register value is stored in
-// `SPSR_EL1`, where the `I` bit records whether the interrupt is enabled or not.
-// `I::unmask` enable_irqs
-fn unmask_interrupts_for_exception(tf: &TrapFrame) {
-    const I_MASK: u64 = 1 << 7;
-    if tf.spsr & I_MASK != I_MASK {
-        super::enable_irqs();
-    } else {
-        debug!("Interrupts were disabled before exception");
-    }
 }

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -36,13 +36,8 @@ fn handle_page_fault(tf: &TrapFrame, mut access_flags: MappingFlags, is_user: bo
 #[unsafe(no_mangle)]
 fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     let estat = estat::read();
-    let trap = estat.cause();
 
-    if matches!(trap, Trap::Exception(_)) {
-        unmask_interrupts_for_exception(tf);
-    }
-
-    match trap {
+    match estat.cause() {
         #[cfg(feature = "uspace")]
         Trap::Exception(Exception::Syscall) => {
             tf.era += 4;
@@ -76,23 +71,4 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     }
 
     crate::trap::post_trap_callback(tf, from_user);
-}
-
-// Interrupt unmasking function for exception handling.
-// NOTE: It must be invoked after the switch to kernel mode has finished
-//
-// If interrupts were enabled before the exception (`PIE` bit in `PRMD` is set),
-// re-enable interrupts before handling the exception.
-//
-// On loongarch64, when an exception is triggered, records the old value of
-// `IE` domain in `CSR.CRMD` in `PIE` domain in `PRMD`. When the `ERTN`
-// instruction is executed to return from the exception handler, the hardware
-// restores the value of the `PIE` domain to the `IE` domain of `CSR.CRMD`.
-fn unmask_interrupts_for_exception(tf: &TrapFrame) {
-    const PIE: usize = 1 << 2;
-    if tf.prmd & PIE == PIE {
-        super::enable_irqs();
-    } else {
-        debug!("Interrupts were disabled before exception");
-    }
 }

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -1,4 +1,3 @@
-use memory_addr::VirtAddr;
 use page_table_entry::MappingFlags;
 use riscv::interrupt::Trap;
 use riscv::interrupt::supervisor::{Exception as E, Interrupt as I};
@@ -17,15 +16,11 @@ fn handle_breakpoint(sepc: &mut usize) {
     *sepc += 2
 }
 
-fn handle_page_fault(
-    tf: &TrapFrame,
-    vaddr: VirtAddr,
-    mut access_flags: MappingFlags,
-    is_user: bool,
-) {
+fn handle_page_fault(tf: &TrapFrame, mut access_flags: MappingFlags, is_user: bool) {
     if is_user {
         access_flags |= MappingFlags::USER;
     }
+    let vaddr = va!(stval::read());
     if !handle_trap!(PAGE_FAULT, vaddr, access_flags, is_user) {
         panic!(
             "Unhandled {} Page Fault @ {:#x}, fault_vaddr={:#x} ({:?}):\n{:#x?}",
@@ -42,12 +37,6 @@ fn handle_page_fault(
 fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     let scause = scause::read();
     if let Ok(cause) = scause.cause().try_into::<I, E>() {
-        // Interrupts modify the value of `stval`, which must be saved before the
-        // interrupt is enabled
-        let vaddr = va!(stval::read());
-        if scause.is_exception() {
-            unmask_interrupts_for_exception(tf);
-        }
         match cause {
             #[cfg(feature = "uspace")]
             Trap::Exception(E::UserEnvCall) => {
@@ -55,13 +44,13 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 tf.regs.a0 = crate::trap::handle_syscall(tf, tf.regs.a7) as usize;
             }
             Trap::Exception(E::LoadPageFault) => {
-                handle_page_fault(tf, vaddr, MappingFlags::READ, from_user)
+                handle_page_fault(tf, MappingFlags::READ, from_user)
             }
             Trap::Exception(E::StorePageFault) => {
-                handle_page_fault(tf, vaddr, MappingFlags::WRITE, from_user)
+                handle_page_fault(tf, MappingFlags::WRITE, from_user)
             }
             Trap::Exception(E::InstructionPageFault) => {
-                handle_page_fault(tf, vaddr, MappingFlags::EXECUTE, from_user)
+                handle_page_fault(tf, MappingFlags::EXECUTE, from_user)
             }
             Trap::Exception(E::Breakpoint) => handle_breakpoint(&mut tf.sepc),
             Trap::Interrupt(_) => {
@@ -79,23 +68,5 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             tf.sepc,
             tf
         );
-    }
-}
-
-// Interrupt unmasking function for exception handling.
-// NOTE: It must be invoked after the switch to kernel mode has finished
-//
-// If interrupts were enabled before the exception (the `SPIE` bit in the
-// `sstatus` register is set), re-enable interrupts before exception handling
-//
-// On riscv64, when an exception occurs, `sstatus.SIE` is set to zero to mask
-// the interrupt and the old value of `SIE` is stored in SPIE. Recover `SIE`
-// according to `SPIE` when using `sret`.
-fn unmask_interrupts_for_exception(tf: &TrapFrame) {
-    const PIE: usize = 1 << 5;
-    if tf.sstatus & PIE == PIE {
-        super::enable_irqs();
-    } else {
-        debug!("Interrupts were disabled before exception");
     }
 }

--- a/modules/axhal/src/arch/x86_64/syscall.rs
+++ b/modules/axhal/src/arch/x86_64/syscall.rs
@@ -22,8 +22,6 @@ pub(super) fn handle_syscall(tf: &mut TrapFrame) {
 #[unsafe(no_mangle)]
 fn x86_syscall_handler(tf: &mut TrapFrame) {
     super::tls::switch_to_kernel_fs_base(tf);
-    #[cfg(target_os = "none")]
-    super::trap::unmask_interrupts_for_exception(tf);
     handle_syscall(tf);
     crate::trap::post_trap_callback(tf, true);
     super::tls::switch_to_user_fs_base(tf);

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -33,9 +33,6 @@ fn handle_page_fault(tf: &TrapFrame) {
 fn x86_trap_handler(tf: &mut TrapFrame) {
     #[cfg(feature = "uspace")]
     super::tls::switch_to_kernel_fs_base(tf);
-    if !matches!(tf.vector as u8, IRQ_VECTOR_START..=IRQ_VECTOR_END) {
-        unmask_interrupts_for_exception(tf);
-    }
     match tf.vector as u8 {
         PAGE_FAULT_VECTOR => handle_page_fault(tf),
         BREAKPOINT_VECTOR => debug!("#BP @ {:#x} ", tf.rip),
@@ -96,20 +93,5 @@ fn err_code_to_flags(err_code: u64) -> Result<MappingFlags, u64> {
             flags |= MappingFlags::EXECUTE;
         }
         Ok(flags)
-    }
-}
-
-// Interrupt unmasking function for exception handling.
-// NOTE: It must be invoked after the switch to kernel mode has finished
-//
-// If interrupts were enabled before the exception (`IF` bit in `RFlags`
-// is set), re-enable interrupts before handling the exception.
-pub(super) fn unmask_interrupts_for_exception(tf: &TrapFrame) {
-    use x86_64::registers::rflags::RFlags;
-    const IF: u64 = RFlags::INTERRUPT_FLAG.bits();
-    if tf.rflags & IF == IF {
-        super::enable_irqs();
-    } else {
-        debug!("Interrupts were disabled before exception");
     }
 }


### PR DESCRIPTION
This reverts commit bd0f8f79350366f965b5544474f216a265a11545. It will revert PR #42. 

#42 enable `irq` before processing an exception when the `irq` is enabled before the exception happened.Now it sill have a bug. Before you restore the context from the trap you need to disable the irq. Otherwise, when an interrupt occurs in the critical area, it will cause register confusion.