### PR TITLE
fix: Disable interrupts before switching contexts

### DIFF
--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -108,7 +108,7 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
     let esr = ESR_EL1.extract();
     let iss = esr.read(ESR_EL1::ISS);
 
-    unmask_interrupts_for_exception(tf);
+    unmask_irqs(tf);
 
     match esr.read_as_enum(ESR_EL1::EC) {
         #[cfg(feature = "uspace")]
@@ -134,7 +134,7 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
         }
     }
     crate::trap::post_trap_callback(tf, source.is_from_user());
-    mask_interrupts_after_exception();
+    mask_irqs();
 }
 
 // Interrupt unmasking function for exception handling.
@@ -146,7 +146,7 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
 // On aarch64, when an exception occurs, the `CPSR` register value is stored in
 // `SPSR_EL1`, where the `I` bit records whether the interrupt is enabled or not.
 // `I::unmask` enable_irqs
-fn unmask_interrupts_for_exception(tf: &TrapFrame) {
+fn unmask_irqs(tf: &TrapFrame) {
     const I_MASK: u64 = 1 << 7;
     if tf.spsr & I_MASK != I_MASK {
         super::enable_irqs();
@@ -155,6 +155,6 @@ fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     }
 }
 
-fn mask_interrupts_after_exception() {
+fn mask_irqs() {
     super::disable_irqs();
 }

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -133,6 +133,7 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
             );
         }
     }
+    mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, source.is_from_user());
 }
 
@@ -152,4 +153,8 @@ fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     } else {
         debug!("Interrupts were disabled before exception");
     }
+}
+
+fn mask_interrupts_after_exception() {
+    super::disable_irqs();
 }

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -133,8 +133,8 @@ fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
             );
         }
     }
-    mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, source.is_from_user());
+    mask_interrupts_after_exception();
 }
 
 // Interrupt unmasking function for exception handling.

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -39,7 +39,7 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
     let trap = estat.cause();
 
     if matches!(trap, Trap::Exception(_)) {
-        unmask_interrupts_for_exception(tf);
+        unmask_irqs(tf);
     }
 
     match trap {
@@ -75,7 +75,7 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
         }
     }
     crate::trap::post_trap_callback(tf, from_user);
-    mask_interrupts_after_exception();
+    mask_irqs();
 }
 
 // Interrupt unmasking function for exception handling.
@@ -88,7 +88,7 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
 // `IE` domain in `CSR.CRMD` in `PIE` domain in `PRMD`. When the `ERTN`
 // instruction is executed to return from the exception handler, the hardware
 // restores the value of the `PIE` domain to the `IE` domain of `CSR.CRMD`.
-fn unmask_interrupts_for_exception(tf: &TrapFrame) {
+fn unmask_irqs(tf: &TrapFrame) {
     const PIE: usize = 1 << 2;
     if tf.prmd & PIE == PIE {
         super::enable_irqs();
@@ -97,6 +97,6 @@ fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     }
 }
 
-fn mask_interrupts_after_exception() {
+fn mask_irqs() {
     super::disable_irqs();
 }

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -74,8 +74,8 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             );
         }
     }
-    mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, from_user);
+    mask_interrupts_after_exception();
 }
 
 // Interrupt unmasking function for exception handling.

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -74,7 +74,7 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             );
         }
     }
-
+    mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, from_user);
 }
 
@@ -95,4 +95,8 @@ fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     } else {
         debug!("Interrupts were disabled before exception");
     }
+}
+
+fn mask_interrupts_after_exception() {
+    super::disable_irqs();
 }

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -71,6 +71,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
+        mask_interrupts_after_exception();
         crate::trap::post_trap_callback(tf, from_user);
     } else {
         panic!(
@@ -98,4 +99,8 @@ fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     } else {
         debug!("Interrupts were disabled before exception");
     }
+}
+
+fn mask_interrupts_after_exception() {
+    super::disable_irqs();
 }

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -71,8 +71,8 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
-        mask_interrupts_after_exception();
         crate::trap::post_trap_callback(tf, from_user);
+        mask_interrupts_after_exception();
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -46,7 +46,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
         // interrupt is enabled
         let vaddr = va!(stval::read());
         if scause.is_exception() {
-            unmask_interrupts_for_exception(tf);
+            unmask_irqs(tf);
         }
         match cause {
             #[cfg(feature = "uspace")]
@@ -72,7 +72,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             }
         }
         crate::trap::post_trap_callback(tf, from_user);
-        mask_interrupts_after_exception();
+        mask_irqs();
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",
@@ -92,7 +92,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
 // On riscv64, when an exception occurs, `sstatus.SIE` is set to zero to mask
 // the interrupt and the old value of `SIE` is stored in SPIE. Recover `SIE`
 // according to `SPIE` when using `sret`.
-fn unmask_interrupts_for_exception(tf: &TrapFrame) {
+fn unmask_irqs(tf: &TrapFrame) {
     const PIE: usize = 1 << 5;
     if tf.sstatus & PIE == PIE {
         super::enable_irqs();
@@ -101,6 +101,6 @@ fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     }
 }
 
-fn mask_interrupts_after_exception() {
+fn mask_irqs() {
     super::disable_irqs();
 }

--- a/modules/axhal/src/arch/x86_64/syscall.rs
+++ b/modules/axhal/src/arch/x86_64/syscall.rs
@@ -25,6 +25,8 @@ fn x86_syscall_handler(tf: &mut TrapFrame) {
     #[cfg(target_os = "none")]
     super::trap::unmask_interrupts_for_exception(tf);
     handle_syscall(tf);
+    #[cfg(target_os = "none")]
+    super::trap::mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, true);
     super::tls::switch_to_user_fs_base(tf);
 }

--- a/modules/axhal/src/arch/x86_64/syscall.rs
+++ b/modules/axhal/src/arch/x86_64/syscall.rs
@@ -23,12 +23,12 @@ pub(super) fn handle_syscall(tf: &mut TrapFrame) {
 fn x86_syscall_handler(tf: &mut TrapFrame) {
     super::tls::switch_to_kernel_fs_base(tf);
     #[cfg(target_os = "none")]
-    super::trap::unmask_interrupts_for_exception(tf);
+    super::trap::unmask_irqs(tf);
     handle_syscall(tf);
     crate::trap::post_trap_callback(tf, true);
     super::tls::switch_to_user_fs_base(tf);
     #[cfg(target_os = "none")]
-    super::trap::mask_interrupts_after_exception();
+    super::trap::mask_irqs();
 }
 
 /// Initializes syscall support and setups the syscall handler.

--- a/modules/axhal/src/arch/x86_64/syscall.rs
+++ b/modules/axhal/src/arch/x86_64/syscall.rs
@@ -25,10 +25,10 @@ fn x86_syscall_handler(tf: &mut TrapFrame) {
     #[cfg(target_os = "none")]
     super::trap::unmask_interrupts_for_exception(tf);
     handle_syscall(tf);
-    #[cfg(target_os = "none")]
-    super::trap::mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, true);
     super::tls::switch_to_user_fs_base(tf);
+    #[cfg(target_os = "none")]
+    super::trap::mask_interrupts_after_exception();
 }
 
 /// Initializes syscall support and setups the syscall handler.

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -34,7 +34,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
     #[cfg(feature = "uspace")]
     super::tls::switch_to_kernel_fs_base(tf);
     if !matches!(tf.vector as u8, IRQ_VECTOR_START..=IRQ_VECTOR_END) {
-        unmask_interrupts_for_exception(tf);
+        unmask_irqs(tf);
     }
     match tf.vector as u8 {
         PAGE_FAULT_VECTOR => handle_page_fault(tf),
@@ -64,7 +64,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
     crate::trap::post_trap_callback(tf, tf.is_user());
     #[cfg(feature = "uspace")]
     super::tls::switch_to_user_fs_base(tf);
-    mask_interrupts_after_exception();
+    mask_irqs();
 }
 
 fn vec_to_str(vec: u64) -> &'static str {
@@ -105,7 +105,7 @@ fn err_code_to_flags(err_code: u64) -> Result<MappingFlags, u64> {
 //
 // If interrupts were enabled before the exception (`IF` bit in `RFlags`
 // is set), re-enable interrupts before handling the exception.
-pub(super) fn unmask_interrupts_for_exception(tf: &TrapFrame) {
+pub(super) fn unmask_irqs(tf: &TrapFrame) {
     use x86_64::registers::rflags::RFlags;
     const IF: u64 = RFlags::INTERRUPT_FLAG.bits();
     if tf.rflags & IF == IF {
@@ -115,6 +115,6 @@ pub(super) fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     }
 }
 
-pub(super) fn mask_interrupts_after_exception() {
+pub(super) fn mask_irqs() {
     super::disable_irqs();
 }

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -61,10 +61,10 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
-    mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, tf.is_user());
     #[cfg(feature = "uspace")]
     super::tls::switch_to_user_fs_base(tf);
+    mask_interrupts_after_exception();
 }
 
 fn vec_to_str(vec: u64) -> &'static str {

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -61,6 +61,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
+    mask_interrupts_after_exception();
     crate::trap::post_trap_callback(tf, tf.is_user());
     #[cfg(feature = "uspace")]
     super::tls::switch_to_user_fs_base(tf);
@@ -112,4 +113,8 @@ pub(super) fn unmask_interrupts_for_exception(tf: &TrapFrame) {
     } else {
         debug!("Interrupts were disabled before exception");
     }
+}
+
+pub(super) fn mask_interrupts_after_exception() {
+    super::disable_irqs();
 }


### PR DESCRIPTION
## Description  
<!-- Provide a brief summary of the changes you made and why they are necessary. -->

The interrupt is turned off after `exception_handler` ends before `trap_handler` ends

## Related Issues(If necessary)  
<!-- Link related issues using `Fixes #issue_number` or `Closes #issue_number` syntax. -->  

https://github.com/oscomp/arceos/pull/42#issuecomment-2883966765

## Implementation Details  
<!-- Describe key technical details or approaches used in this PR. If applicable, include relevant screenshots or logs. -->

Add the `mask_interrupts_after_exception` function

* Complements `unmask_interrupts_for_exception` and improves readability

## How to Test  
<!-- Provide step-by-step instructions on how to test your changes. Mention any dependencies, test cases, or commands that should be run. -->

> Tips: Please provide the **test results** of running testcases for [starry-next](https://github.com/oscomp/starry-next) on the commit corresponding to your PR. You can paste it here in the form of a screenshot, or provide a CI link to **a branch or fork of starry-next** for us to review.

Before `trap_handler` ends, add `asser!(!super::irqs_enabled())`, again before `syscall_handler` ends in x86_64.

