### PR TITLE
Add `fsync` in `fatfs` and `lwext4_rust` filesystem

### DIFF
--- a/modules/axfs/src/fs/fatfs.rs
+++ b/modules/axfs/src/fs/fatfs.rs
@@ -96,6 +96,10 @@ impl<IO: IoTrait> VfsNodeOps for FileWrapper<'static, IO> {
         file.seek(SeekFrom::Start(size)).map_err(as_vfs_err)?; // TODO: more efficient
         file.truncate().map_err(as_vfs_err)
     }
+
+    fn fsync(&self) -> VfsResult {
+        self.0.lock().flush().map_err(as_vfs_err)
+    }
 }
 
 impl<IO: IoTrait> VfsNodeOps for DirWrapper<'static, IO> {

--- a/modules/axfs/src/fs/lwext4_rust.rs
+++ b/modules/axfs/src/fs/lwext4_rust.rs
@@ -301,6 +301,13 @@ impl VfsNodeOps for FileWrapper {
         r.map_err(|e| e.try_into().unwrap())
     }
 
+    fn fsync(&self) -> VfsResult {
+        let mut file = self.0.lock();
+        file.file_cache_flush()
+            .map(|_v| ())
+            .map_err(|e| e.try_into().unwrap())
+    }
+
     fn truncate(&self, size: u64) -> VfsResult {
         let mut file = self.0.lock();
         let path = file.get_path();


### PR DESCRIPTION
## Description  
The function is used for synchronizing files. We found it when we test `axfs` API.

## How to Test  


### Test code

We write test code in the `examples/fs-test`.

```rust
/// examples/fs-test/src/main.rs

#![no_std]
#![no_main]

#[macro_use]
extern crate axlog;
extern crate alloc;
extern crate axruntime;

use alloc::string::String;
use axerrno::AxResult;
use axfs::fops;

/// create a OpenOptions
fn options(opt: &str) -> fops::OpenOptions {
    let mut opts = fops::OpenOptions::new();
    opt.find("r").map(|_| opts.read(true));
    opt.find("w").map(|_| opts.write(true));
    opt.find("x").map(|_| opts.execute(true));
    opt.find("a").map(|_| opts.append(true));
    opt.find("t").map(|_| opts.truncate(true));
    opt.find("c").map(|_| opts.create(true));
    opt.find("n").map(|_| opts.create_new(true));
    opt.find("d").map(|_| opts.directory(true));
    opts
}

fn test_file_api() -> AxResult {
    debug!("test_file_api");

    let s = String::from("hello world");
    let file_path = "/test.txt";

    // write
    let mut file = fops::File::open(file_path, &options("rwc"))?;
    file.write(s.as_bytes())?;
    file.flush()?; // unimplement function

    // read
    let mut file = fops::File::open(file_path, &options("r"))?;
    let mut buf = [0u8; 64];
    let len = file.read(&mut buf)?;
    assert_eq!(&buf[0..len], s.as_bytes());

    // delete
    let dir = fops::Directory::open_dir("/", &options("r"))?;
    dir.remove_file(file_path)?;

    ax_println!("pass!");
    Ok(())
}

#[unsafe(no_mangle)]
fn main() {
    test_file_api().expect("test file api failed");
}
```

```toml
[package]
name = "fs-test"
version = "0.1.0"
edition.workspace = true

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[features]
default = []

[dependencies]
axfeat = { workspace=true, features = [
    "fs",
]}
axfs.workspace = true
axlog.workspace = true
axruntime.workspace = true

axerrno = "0.1"
axio = { version = "0.1.1", features = ["alloc"] }
```

Then, run command below:
```sh
make disk_img
NO_AXSTD=y AX_LIB=axfeat make NET=y BLK=y A=examples/fs-test run
```


### before

- If we run `file.flush()?`, it will panic at `InvalidInput`.
```text
[  0.200840 0 fatfs::dir:139] Is a directory
[  0.211265 0 fatfs::dir:139] Is a directory
[  0.222088 0 fatfs::dir:139] Is a directory
[  0.235326 0 fatfs::dir:139] Is a directory
[  0.250344 0 axfs_vfs:117] [AxError::InvalidInput]
[  0.251235 0 axruntime::lang_items:5] panicked at examples/fs-test/src/main.rs:56:21:
test file api failed: InvalidInput
```

- If we don't `file.flush()?`, it will get a wrong result.
```text
[  0.195042 0 fatfs::dir:139] Is a directory
[  0.199027 0 fatfs::dir:139] Is a directory
[  0.204235 0 fatfs::dir:139] Is a directory
[  0.211167 0 fatfs::dir:139] Is a directory
[  0.230818 0 axruntime::lang_items:5] panicked at examples/fs-test/src/main.rs:44:5:
assertion `left == right` failed
  left: []
 right: [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
```

### After
```text
[  0.201865 0 fatfs::dir:139] Is a directory
[  0.206296 0 fatfs::dir:139] Is a directory
[  0.212115 0 fatfs::dir:139] Is a directory
[  0.218929 0 fatfs::dir:139] Is a directory
pass!
```
