### PR TITLE
fix: ensure data is copied to kernel address space before convert VA to PA

### DIFF
--- a/modules/axfs/src/dev.rs
+++ b/modules/axfs/src/dev.rs
@@ -70,7 +70,11 @@ impl Disk {
     pub fn write_one(&mut self, buf: &[u8]) -> DevResult<usize> {
         let write_size = if self.offset == 0 && buf.len() >= BLOCK_SIZE {
             // whole block
-            self.dev.write_block(self.block_id, &buf[0..BLOCK_SIZE])?;
+            // copy data to kernel address space
+            // Because underlying driver assumes a linear mapping between virtual address and
+            // physical address when converting them, which is only present in kernel address space.
+            let data = buf[0..BLOCK_SIZE].to_vec();
+            self.dev.write_block(self.block_id, &data)?;
             self.block_id += 1;
             BLOCK_SIZE
         } else {

--- a/modules/axhal/src/mem.rs
+++ b/modules/axhal/src/mem.rs
@@ -54,6 +54,10 @@ pub struct MemRegion {
 /// `paddr = vaddr - PHYS_VIRT_OFFSET`.
 #[inline]
 pub const fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
+    assert!(
+        vaddr.as_usize() >= PHYS_VIRT_OFFSET,
+        "Converted address is invalid, check if the virtual address is in kernel space"
+    );
     pa!(vaddr.as_usize() - PHYS_VIRT_OFFSET)
 }
 


### PR DESCRIPTION
## Description  
<!-- Provide a brief summary of the changes you made and why they are necessary. -->

Underlying driver assumes a linear mapping between virtual address and physical address when converting them, which is only present in kernel address space. So under circumstance related to physical address, we should copy the buffer to kernel space.

(cherry picked from commit 25abd286d83d4f380ae2e52b446b63b9ffdec014)

## Related Issues(If necessary)  
<!-- Link related issues using `Fixes #issue_number` or `Closes #issue_number` syntax. -->  

- `sys_write` will finally call `axfs::dev::Disk::write_one` in dev.rs, which will use the buffer directly.
- read from stdin will finally call `console_read_bytes`， which will also use the buffer directly.

## Implementation Details  
<!-- Describe key technical details or approaches used in this PR. If applicable, include relevant screenshots or logs. -->

Make sure that the buffer is in kernel address space so that there is a linear mapping between virtual address and physical address.
