### PR TITLE
fix: Incorrect flags for `handle_cow_fault` in `populate_area`

### DIFF
--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -287,7 +287,8 @@ impl AddrSpace {
                                     && !Self::handle_cow_fault(
                                         addr,
                                         paddr,
-                                        flags,
+                                        // Add write to flags (area.flags contains write)
+                                        area.flags(),
                                         page_size,
                                         &mut self.pt,
                                     )
@@ -674,6 +675,8 @@ impl AddrSpace {
         align: PageSize,
         pt: &mut PageTable,
     ) -> bool {
+        assert!(flags.contains(MappingFlags::WRITE));
+
         let paddr = paddr.align_down(align);
 
         match frame_table().ref_count(paddr) {


### PR DESCRIPTION
`handle_cow_fault` in `populate_area` uses pte flags, which has removed the write flag.

Should use the `area.flags()`.
